### PR TITLE
Make wire protocol actually work.

### DIFF
--- a/project1/CMakeLists.txt
+++ b/project1/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.17)
 project(project1 CXX)
 
 set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_FLAGS "-Wall -Werror")
+
+include(googletest.cmake)
 
 add_subdirectory(server)
 add_subdirectory(wire_protocol)

--- a/project1/googletest-download.cmake.in
+++ b/project1/googletest-download.cmake.in
@@ -1,0 +1,17 @@
+# Used to download GTest at configure time.
+
+cmake_minimum_required(VERSION 2.8.12)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           master
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/project1/googletest.cmake
+++ b/project1/googletest.cmake
@@ -1,0 +1,31 @@
+# Download and unpack googletest at configure time
+configure_file(googletest-download.cmake.in googletest-download/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+        RESULT_VARIABLE result
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+if(result)
+    message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+endif()
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+        RESULT_VARIABLE result
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+if(result)
+    message(FATAL_ERROR "Build step for googletest failed: ${result}")
+endif()
+
+# Prevent overriding the parent project's compiler/linker
+# settings on Windows
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+# Add googletest directly to our build. This defines
+# the gtest and gtest_main targets.
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+        ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+        EXCLUDE_FROM_ALL)
+
+# The gtest/gtest_main targets carry header search path
+# dependencies automatically when using CMake 2.8.11 or
+# later. Otherwise we have to add them here ourselves.
+if (CMAKE_VERSION VERSION_LESS 2.8.11)
+    include_directories("${gtest_SOURCE_DIR}/include")
+endif()

--- a/project1/wire_protocol/CMakeLists.txt
+++ b/project1/wire_protocol/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(proto)
+add_subdirectory(tests)
 
 add_library(wire_protocol wire_protocol.cpp)
 # Make sure we can access the generated protobuf files.
-target_include_directories(wire_protocol PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(wire_protocol proto ${PROTOBUF_LIBRARY})
+target_link_libraries(wire_protocol PUBLIC proto)

--- a/project1/wire_protocol/proto/CMakeLists.txt
+++ b/project1/wire_protocol/proto/CMakeLists.txt
@@ -1,6 +1,10 @@
-INCLUDE(FindProtobuf)
-FIND_PACKAGE(Protobuf REQUIRED)
+include(FindProtobuf)
+find_package(Protobuf REQUIRED)
 
-INCLUDE_DIRECTORIES(${PROTOBUF_INCLUDE_DIR})
+include_directories(${PROTOBUF_INCLUDE_DIR})
 PROTOBUF_GENERATE_CPP(PROTO_SRC PROTO_HEADER ftp_messages.proto)
 add_library(proto ${PROTO_HEADER} ${PROTO_SRC})
+# Instruct everything that links to this to also link to Protobuf.
+target_link_libraries(proto INTERFACE ${Protobuf_LIBRARIES})
+# Make sure everything that depends on this can find the headers.
+target_include_directories(proto INTERFACE ${CMAKE_CURRENT_BINARY_DIR})

--- a/project1/wire_protocol/tests/CMakeLists.txt
+++ b/project1/wire_protocol/tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable(test_wire_protocol test_wire_protocol.cpp)
+target_link_libraries(test_wire_protocol gtest_main proto wire_protocol
+        ${PROTOBUF_LIBRARY})
+add_test(NAME test_wire_protocol COMMAND test_wire_protocol)

--- a/project1/wire_protocol/tests/test_wire_protocol.cpp
+++ b/project1/wire_protocol/tests/test_wire_protocol.cpp
@@ -1,0 +1,156 @@
+/**
+ * @file Unit tests for `wire_protocol`.
+ */
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "../wire_protocol.h"
+#include "ftp_messages.pb.h"
+#include "gtest/gtest.h"
+
+namespace wire_protocol::tests {
+
+using ftp_messages::GetRequest;
+
+namespace {
+
+/// File name to use for test messages.
+const char* kTestFileName = "my_file.txt";
+
+/**
+ * @brief Creates a message to use for testing.
+ * @return The message that it created.
+ */
+GetRequest MakeTestMessage() {
+  GetRequest test_message;
+  test_message.set_filename(kTestFileName);
+
+  return test_message;
+}
+
+/**
+ * @brief Fixture to use for tests that split the message at different points.
+ */
+class WireProtocolSplitMessage : public ::testing::TestWithParam<uint32_t> {};
+
+}  // namespace
+
+/**
+ * @test Tests that we can serialize a message and then deserialize it
+ * successfully.
+ */
+TEST(WireProtocol, RoundTrip) {
+  // Arrange.
+  // Create a message.
+  const auto kTestMessage = MakeTestMessage();
+
+  // Parser to deserialize with.
+  MessageParser<GetRequest> parser;
+
+  std::vector<uint8_t> serialized;
+
+  // Act.
+  const bool kSerializedSuccess = Serialize(kTestMessage, &serialized);
+  parser.AddNewData(serialized);
+
+  // Assert.
+  // The serialization should have succeeded.
+  ASSERT_TRUE(kSerializedSuccess);
+  // The parser should indicate that the message is complete.
+  EXPECT_TRUE(parser.HasCompleteMessage());
+
+  // We should read the correct message.
+  GetRequest got_message;
+  EXPECT_TRUE(parser.GetMessage(&got_message));
+  EXPECT_STREQ(kTestFileName, got_message.filename().c_str());
+}
+
+/**
+ * @test Tests that the parser can handle a message that has been split up.
+ */
+TEST_P(WireProtocolSplitMessage, RoundTripPartialMessage) {
+  // Arrange.
+  // Create a message.
+  const auto kTestMessage = MakeTestMessage();
+
+  // Serialize the message.
+  std::vector<uint8_t> serialized;
+  ASSERT_TRUE(Serialize(kTestMessage, &serialized));
+
+  // Split the serialized message into two parts.
+  const auto kSplitAt = GetParam();
+  std::vector<uint8_t> serialized_part_1(serialized.begin(),
+                                         serialized.begin() + kSplitAt);
+  std::vector<uint8_t> serialized_part_2(serialized.begin() + kSplitAt,
+                                         serialized.end());
+
+  // Act.
+  MessageParser<GetRequest> parser;
+  parser.AddNewData(serialized_part_1);
+  const bool kHasMessageAfterFirstPart = parser.HasCompleteMessage();
+  parser.AddNewData(serialized_part_2);
+
+  // Assert.
+  // It should not have a complete message until the second part.
+  EXPECT_FALSE(kHasMessageAfterFirstPart);
+  EXPECT_TRUE(parser.HasCompleteMessage());
+
+  // We should read the correct message.
+  GetRequest got_message;
+  EXPECT_TRUE(parser.GetMessage(&got_message));
+  EXPECT_STREQ(kTestFileName, got_message.filename().c_str());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SplitMessageTests, WireProtocolSplitMessage,
+    // Last value here splits in the middle of the message data.
+    ::testing::Values(1, 4, 4 + MakeTestMessage().ByteSizeLong() / 2));
+
+/**
+ * @test Tests that we can parse multiple messages when they arrive together.
+ */
+TEST(WireProtocol, RoundTripMultiMessage) {
+  // Arrange.
+  // Create messages.
+  const auto kTestMessage1 = MakeTestMessage();
+  const auto kTestMessage2 = MakeTestMessage();
+
+  // Serialize the messages.
+  std::vector<uint8_t> serialized_1;
+  ASSERT_TRUE(Serialize(kTestMessage1, &serialized_1));
+  std::vector<uint8_t> serialized_2;
+  ASSERT_TRUE(Serialize(kTestMessage2, &serialized_2));
+
+  // Combine into one data stream.
+  std::vector<uint8_t> combined(serialized_1.size() + serialized_2.size());
+  std::copy(serialized_1.begin(), serialized_1.end(), combined.begin());
+  std::copy(serialized_2.begin(), serialized_2.end(),
+            combined.begin() + serialized_1.size());
+
+  // Act.
+  MessageParser<GetRequest> parser;
+  parser.AddNewData(combined);
+
+  // Assert.
+  // It should have a complete message.
+  EXPECT_TRUE(parser.HasCompleteMessage());
+
+  // The first message should be intact.
+  GetRequest got_message;
+  EXPECT_TRUE(parser.GetMessage(&got_message));
+  EXPECT_STREQ(kTestFileName, got_message.filename().c_str());
+
+  // It should still have the second message.
+  EXPECT_TRUE(parser.HasCompleteMessage());
+
+  // The second message should be intact.
+  EXPECT_TRUE(parser.GetMessage(&got_message));
+  EXPECT_STREQ(kTestFileName, got_message.filename().c_str());
+
+  // It should have no more messages.
+  EXPECT_FALSE(parser.HasCompleteMessage());
+}
+
+}  // namespace wire_protocol::tests

--- a/project1/wire_protocol/wire_protocol.cpp
+++ b/project1/wire_protocol/wire_protocol.cpp
@@ -1,6 +1,5 @@
 #include "wire_protocol.h"
 
-
 namespace wire_protocol {
 
 bool Serialize(const google::protobuf::Message& message,
@@ -9,7 +8,9 @@ bool Serialize(const google::protobuf::Message& message,
   const uint32_t kMessageSize = message.ByteSizeLong();
   const uint32_t kMessageSizeNetwork = htonl(kMessageSize);
   serialized->resize(sizeof(kMessageSize) + kMessageSize);
-  std::copy(&kMessageSizeNetwork, &kMessageSizeNetwork + 1, serialized->data());
+  std::copy(reinterpret_cast<const uint8_t*>(&kMessageSizeNetwork),
+            reinterpret_cast<const uint8_t*>(&kMessageSizeNetwork + 1),
+            serialized->data());
 
   // Serialize the actual message.
   return message.SerializeToArray(

--- a/project1/wire_protocol/wire_protocol.h
+++ b/project1/wire_protocol/wire_protocol.h
@@ -8,13 +8,14 @@
 #include <arpa/inet.h>
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <limits>
 #include <type_traits>
 #include <vector>
 
+#include "ftp_messages.pb.h"
 #include "google/protobuf/message.h"
-#include "proto/ftp_messages.pb.h"
 
 namespace wire_protocol {
 
@@ -38,40 +39,37 @@ class MessageParser {
   static_assert(std::is_base_of<google::protobuf::Message, MessageType>::value,
                 "Can only make parsers for protobuf messages.");
 
+  /// Type we use to store the length in serialized messages.
+  using MessageLengthType = uint32_t;
+  /// Size of the length prefix to each message.
+  static constexpr uint8_t kNumLengthBytes = sizeof(MessageLengthType);
+
+  /// Keeps track of which state the parser is in.
+  enum class ParserState {
+    /// Parsing the length.
+    PARSING_LENGTH,
+    /// Parsing the message.
+    PARSING_MESSAGE,
+    /// Parsed a complete message.
+    PARSING_DONE,
+  };
+
  public:
   /**
    * @brief Adds new serialized data to the parser.
    * @param data The data to add.
-   * @note If a complete message has already been parsed, this method will
-   *    do nothing until `GetMessage()` has been called.
    */
   void AddNewData(const std::vector<uint8_t>& data) {
-    if (HasCompleteMessage()) {
-      // Nothing to do.
-      return;
-    }
-
-    size_t copy_offset = 0;
-    if (partial_message_.empty()) {
-      // This is the first chunk of data. Parse the message length.
-      uint32_t message_size_network;
-      std::copy(data.data(), data.data() + sizeof(message_size_network),
-                &message_size_network);
-      expected_length_ = ntohl(message_size_network);
-
-      // Actual message data starts here.
-      copy_offset = sizeof(message_size_network);
-    }
-
-    // Copy the actual message data.
-    std::copy(data.begin() + copy_offset, data.end(), partial_message_.begin());
+    uint32_t data_offset = ParseLength(data);
+    data_offset += ParseMessage(data, data_offset);
+    SaveOverflow(data, data_offset);
   }
 
   /**
    * @return True if a complete message has been parsed.
    */
   [[nodiscard]] bool HasCompleteMessage() const {
-    return partial_message_.size() == expected_length_;
+    return state_ == ParserState::PARSING_DONE;
   }
 
   /**
@@ -91,18 +89,133 @@ class MessageParser {
     const bool kParseResult =
         message->ParseFromArray(partial_message_.data(), expected_length_);
 
+    // Assume any extra data is the start of a new message.
+    const std::vector<uint8_t> kNewMessageData(overflow_message_data_.begin(),
+                                               overflow_message_data_.end());
     // Reset the internal state to prepare for new messages.
-    partial_message_.clear();
-    expected_length_ = std::numeric_limits<uint32_t>::max();
+    ResetParser();
+    // Parse the start of the next message.
+    AddNewData(kNewMessageData);
 
     return kParseResult;
   };
 
  private:
+  /**
+   * @brief Handles parsing the length from the input data.
+   * @param data The input data.
+   * @return The number of bytes from the input that it consumed.
+   */
+  uint32_t ParseLength(const std::vector<uint8_t>& data) {
+    if (state_ != ParserState::PARSING_LENGTH) {
+      // We are not in the correct state for this.
+      return 0;
+    }
+
+    // Copy any of the remaining length bytes.
+    const uint32_t kLengthBytesToCopy =
+        std::min(static_cast<uint32_t>(data.size()),
+                 kNumLengthBytes - got_length_bytes_);
+    std::copy(data.begin(), data.begin() + kLengthBytesToCopy,
+              partial_length_.begin() + got_length_bytes_);
+    got_length_bytes_ += kLengthBytesToCopy;
+
+    if (got_length_bytes_ == kNumLengthBytes) {
+      // We've parsed the entire length.
+      state_ = ParserState::PARSING_MESSAGE;
+
+      // Actually parse and save the length.
+      MessageLengthType message_size_network;
+      std::copy(partial_length_.begin(), partial_length_.end(),
+                reinterpret_cast<uint8_t*>(&message_size_network));
+      expected_length_ = ntohl(message_size_network);
+    }
+
+    return kLengthBytesToCopy;
+  }
+
+  /**
+   * @brief Handles parsing the message from the input data.
+   * @param data The input data.
+   * @param start_offset The offset from the start of the input data to parse
+   *    from.
+   * @return The number of bytes from the input that it consumed.
+   */
+  uint32_t ParseMessage(const std::vector<uint8_t>& data,
+                        uint32_t start_offset) {
+    if (state_ != ParserState::PARSING_MESSAGE) {
+      // We are not in the correct state for this.
+      return 0;
+    }
+
+    // Determine number of bytes to copy.
+    const uint32_t kRemainingData = data.size() - start_offset;
+    const uint32_t kCurrentLength = partial_message_.size();
+    const uint32_t kNumBytesToCopy =
+        std::min(kRemainingData, expected_length_ - kCurrentLength);
+
+    // Make sure we have enough space.
+    partial_message_.resize(kCurrentLength + kNumBytesToCopy);
+    // Copy the actual message data.
+    std::copy(data.begin() + start_offset,
+              data.begin() + start_offset + kNumBytesToCopy,
+              partial_message_.begin() + kCurrentLength);
+
+    // Check if this message is now complete.
+    if (partial_message_.size() == expected_length_) {
+      state_ = ParserState::PARSING_DONE;
+    }
+
+    return kNumBytesToCopy;
+  }
+
+  /**
+   * @brief Handles parsing any overflow data that belongs to the next message.
+   * @param data The input data.
+   * @param start_offset The offset from the start of the input data to parse
+   *    from.
+   */
+  void SaveOverflow(const std::vector<uint8_t>& data, uint32_t start_offset) {
+    if (state_ != ParserState::PARSING_DONE) {
+      // We are not in the correct state for this.
+      return;
+    }
+
+    // Save any additional data for the next message.
+    const uint32_t kRemainingData = data.size() - start_offset;
+    const uint32_t kCurrentOverflowSize = overflow_message_data_.size();
+
+    overflow_message_data_.resize(kCurrentOverflowSize + kRemainingData);
+    std::copy(data.begin() + start_offset, data.end(),
+              overflow_message_data_.begin() + kCurrentOverflowSize);
+  }
+
+  /**
+   * @brief Resets the parser state.
+   */
+  void ResetParser() {
+    state_ = ParserState::PARSING_LENGTH;
+    got_length_bytes_ = 0;
+    partial_message_.clear();
+    expected_length_ = std::numeric_limits<uint32_t>::max();
+    overflow_message_data_.clear();
+  }
+
+  /// Tracks the current parser state.
+  ParserState state_ = ParserState::PARSING_LENGTH;
+
+  /// The current partial length data.
+  std::array<uint8_t, kNumLengthBytes> partial_length_{};
+  /// How many of the length bytes we've read so far.
+  uint32_t got_length_bytes_ = 0;
+
   /// The current partial message data.
   std::vector<uint8_t> partial_message_{};
   /// The length of the message we're currently reading.
   uint32_t expected_length_ = std::numeric_limits<uint32_t>::max();
+
+  /// Overflow data that belongs to the message after the current one.
+  std::vector<uint8_t> overflow_message_data_{};
 };
 
 }  // namespace wire_protocol


### PR DESCRIPTION
This was done with the help of some unit tests. These tests are located in `project1/wire_protocol/tests`, and should also serve as good examples for anyone trying to use the wire protocol.

Running the unit tests can be done easily using CLion, just by adding a new GTest configuration and selecting `test_wire_protocol` as the executable.