### PR TITLE
Add support for concurrent file access.

### DIFF
--- a/project1/server/file_handler/CMakeLists.txt
+++ b/project1/server/file_handler/CMakeLists.txt
@@ -1,1 +1,5 @@
-add_library(file_handler file_handler.cpp)
+add_subdirectory(tests)
+
+add_library(file_handler file_handler.cpp thread_safe_file_handler.cpp
+        file_access_manager.cpp file_lock_guard.cpp)
+target_link_libraries(file_handler loguru)

--- a/project1/server/file_handler/file_access_manager.cpp
+++ b/project1/server/file_handler/file_access_manager.cpp
@@ -1,0 +1,65 @@
+#include "file_access_manager.h"
+
+#include <loguru.hpp>
+
+namespace server::file_handler {
+namespace {
+
+using std::filesystem::path;
+
+/**
+ * @brief Converts a relative path to a normalized absolute one.
+ * @param relative The relative path to convert.
+ * @return The normalized absolute path.
+ */
+path UniquePath(const path& relative) {
+  if (relative.is_absolute()) {
+    // Nothing more needs to be done.
+    return relative.lexically_normal();
+  }
+
+  // Make it absolute.
+  const path kCurrentDir = std::filesystem::current_path();
+  const path kAbsolute = kCurrentDir / relative;
+  return kAbsolute.lexically_normal();
+}
+
+}  // namespace
+
+void FileAccessManager::LockFile(const path& path) {
+  const auto kPathKey = UniquePath(path).string();
+
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    // Make sure the file is not currently locked.
+    if (locked_files_.find(kPathKey) != locked_files_.end()) {
+      // Wait for file to be unlocked.
+      file_unlocked_.wait(lock, [this, kPathKey]() {
+        return locked_files_.find(kPathKey) == locked_files_.end();
+      });
+    }
+
+    // Lock the file.
+    LOG_S(1) << "Locking " << kPathKey << ".";
+    locked_files_.insert(kPathKey);
+  }
+}
+
+void FileAccessManager::UnlockFile(const path& path) {
+  const auto kPathKey = UniquePath(path).string();
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // Mark the file as unlocked.
+    LOG_S(1) << "Unlocking " << kPathKey << ".";
+    LOG_IF_S(WARNING, locked_files_.find(kPathKey) == locked_files_.end())
+        << "Unlocking file that was never locked.";
+    locked_files_.erase(kPathKey);
+  }
+  // Notify the next waiter.
+  file_unlocked_.notify_one();
+}
+
+}  // namespace server::file_handler

--- a/project1/server/file_handler/file_access_manager.h
+++ b/project1/server/file_handler/file_access_manager.h
@@ -1,0 +1,47 @@
+#ifndef PROJECT1_FILE_ACCESS_MANAGER_H
+#define PROJECT1_FILE_ACCESS_MANAGER_H
+
+#include <filesystem>
+#include <mutex>
+#include <string>
+#include <unordered_set>
+#include <condition_variable>
+
+namespace server::file_handler {
+
+/**
+ * @brief Facilitates synchronization among multiple threads that are
+ *  using the file system.
+ * @details This class is meant to be used with `FileHandlers`. Note that
+ *  a single instance must be shared among threads for it to be effective.
+ */
+class FileAccessManager {
+ public:
+  /**
+   * @brief Locks a particular file. When a file is locked, any calls to
+   *    this method for the same file in other threads will block.
+   * @param path The path to the file.
+   */
+  void LockFile(const std::filesystem::path& path);
+
+  /**
+   * @brief Unlocks a particular file. This will allow other threads to lock
+   *    it.
+   * @param path The path to the file.
+   */
+  void UnlockFile(const std::filesystem::path& path);
+
+ private:
+  /// Protects access to internal data structures.
+  std::mutex mutex_{};
+  /// This variable is notified when a file is unlocked.
+  std::condition_variable file_unlocked_{};
+
+  /// Set of absolute paths to files that are currently locked.
+  std::unordered_set<std::string> locked_files_{};
+
+};
+
+}  // namespace server::file_handler
+
+#endif  // PROJECT1_FILE_ACCESS_MANAGER_H

--- a/project1/server/file_handler/file_handler.cpp
+++ b/project1/server/file_handler/file_handler.cpp
@@ -1,19 +1,20 @@
 #include "file_handler.h"
 
-#include <filesystem>
 namespace server::file_handler {
+
+FileHandler::FileHandler() : current_dir_(std::filesystem::current_path()) {}
+
 bool FileHandler::Delete(const std::string &filename) {
-  return remove(filename.c_str())==0;
+  return remove(filename.c_str()) == 0;
 
 }  // Delete
 bool FileHandler::Put(const std::string &filename,
-                        const std::vector<uint8_t> &contents) {
-  
+                      const std::vector<uint8_t> &contents) {
   // convert contents to string format
   std::string str_contents(contents.begin(), contents.end());
 
   // open file
-  std::ofstream stream(filename);
+  std::ofstream stream(current_dir_ / filename);
 
   // write contents to file
   stream << str_contents;
@@ -24,19 +25,17 @@ bool FileHandler::Put(const std::string &filename,
   return true;
 }  // Put
 bool FileHandler::MakeDir(const std::string &name) {
-  const std::filesystem::path path = name;
-  return std::filesystem::create_directory(path);
+  return std::filesystem::create_directory(current_dir_ / name);
 
 }  // MakeDir
 
 bool FileHandler::ChangeDir(const std::string &sub_folder) {
-  const std::filesystem::path path = sub_folder;
-  std::filesystem::current_path(path);
+  std::filesystem::current_path(current_dir_ / sub_folder);
   return true;
 
 }  // ChangeDir
 std::vector<uint8_t> FileHandler::Get(const std::string &filename) const {
-  std::ifstream stream(filename);
+  std::ifstream stream(current_dir_ / filename);
 
   // get contents of file, convert to byte vector
   std::string str_contents((std::istreambuf_iterator<char>(stream)),
@@ -49,14 +48,17 @@ std::vector<uint8_t> FileHandler::Get(const std::string &filename) const {
 
 }  // Get
 
-bool FileHandler::UpDir() { return chdir("..") != -1; }  // UpDir
+bool FileHandler::UpDir() {
+  current_dir_ = current_dir_.parent_path();
+  return true;
+}  // UpDir
 
 std::vector<std::string> FileHandler::List() const {
   std::vector<std::string> list;
   for (const auto &file :
-       std::filesystem::directory_iterator(GetCurrentDir())) {
+       std::filesystem::directory_iterator(current_dir_)) {
     std::string str(file.path());
-    str.erase(0, GetCurrentDir().length() + 1);
+    str.erase(0, current_dir_.string().length() + 1);
     list.push_back(str);
   }
 
@@ -65,7 +67,8 @@ std::vector<std::string> FileHandler::List() const {
 }  // List
 
 std::string FileHandler::GetCurrentDir() const {
-  return std::filesystem::current_path();
-}  // GetCurrentDir
+  return current_dir_;
+}
+// GetCurrentDir
 
 }  // namespace server::file_handler

--- a/project1/server/file_handler/file_handler.h
+++ b/project1/server/file_handler/file_handler.h
@@ -8,6 +8,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <vector>
@@ -21,13 +22,15 @@
 namespace server::file_handler {
 class FileHandler : public IFileHandler {
  public:
+  FileHandler();
+
   [[nodiscard]] std::vector<uint8_t> Get(
-      const std::string& filename) const final;
+      const std::string& filename) const override;
 
   bool Put(const std::string& filename,
-           const std::vector<uint8_t>& contents) final;
+           const std::vector<uint8_t>& contents) override;
 
-  bool Delete(const std::string& filename) final;
+  bool Delete(const std::string& filename) override;
 
   [[nodiscard]] std::vector<std::string> List() const final;
 
@@ -35,9 +38,13 @@ class FileHandler : public IFileHandler {
 
   bool UpDir() final;
 
-  bool MakeDir(const std::string& name) final;
+  bool MakeDir(const std::string& name) override;
 
   [[nodiscard]] std::string GetCurrentDir() const final;
+
+ private:
+  /// Keeps track of the current directory.
+  std::filesystem::path current_dir_;
 };
 }  // namespace server::file_handler
 #endif  // PROJECT1_FILE_HANDLER_H

--- a/project1/server/file_handler/file_handler_interface.h
+++ b/project1/server/file_handler/file_handler_interface.h
@@ -16,6 +16,8 @@ namespace server::file_handler {
  */
 class IFileHandler {
  public:
+  virtual ~IFileHandler() = default;
+
   /**
    * @brief Gets the contents of a file in the current remote directory on the
    *    server.

--- a/project1/server/file_handler/file_lock_guard.cpp
+++ b/project1/server/file_handler/file_lock_guard.cpp
@@ -1,0 +1,19 @@
+#include "file_lock_guard.h"
+
+#include <utility>
+
+namespace server::file_handler {
+
+FileLockGuard::FileLockGuard(FileAccessManager *manager,
+                             std::filesystem::path path)
+    : manager_(manager), path_(std::move(path)) {
+  // Lock the file.
+  manager_->LockFile(path_);
+}
+
+FileLockGuard::~FileLockGuard() {
+  // Unlock the file.
+  manager_->UnlockFile(path_);
+}
+
+}  // namespace server::file_handler

--- a/project1/server/file_handler/file_lock_guard.h
+++ b/project1/server/file_handler/file_lock_guard.h
@@ -1,0 +1,33 @@
+#ifndef PROJECT1_FILE_LOCK_GUARD_H
+#define PROJECT1_FILE_LOCK_GUARD_H
+
+#include <filesystem>
+
+#include "file_access_manager.h"
+
+namespace server::file_handler {
+
+/**
+ * @brief Trivial class that acts as the equivalent of `std::lock_guard` but
+ *  with `FileAccessManagers`.
+ */
+class FileLockGuard {
+ public:
+  /**
+   * @param manager The `FileAccessManager` to use for locking.
+   * @param path The path to the file to lock.
+   */
+  FileLockGuard(FileAccessManager* manager, std::filesystem::path path);
+
+  ~FileLockGuard();
+
+ private:
+  /// Internal FileAccessManager to use for locking.
+  FileAccessManager* manager_;
+  /// Path that we have locked.
+  std::filesystem::path path_;
+};
+
+}  // namespace server::file_handler
+
+#endif  // PROJECT1_FILE_LOCK_GUARD_H

--- a/project1/server/file_handler/tests/CMakeLists.txt
+++ b/project1/server/file_handler/tests/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(test_thread_safe_file_handler test_thread_safe_file_handler.cpp)
+target_link_libraries(test_thread_safe_file_handler gtest_main file_handler)
+add_test(NAME test_thread_safe_file_handler COMMAND test_thread_safe_file_handler)

--- a/project1/server/file_handler/tests/test_thread_safe_file_handler.cpp
+++ b/project1/server/file_handler/tests/test_thread_safe_file_handler.cpp
@@ -1,0 +1,222 @@
+#include <cstdint>
+#include <ctime>
+#include <filesystem>
+#include <memory>
+#include <random>
+#include <sstream>
+#include <thread>
+#include <vector>
+
+#include "../file_access_manager.h"
+#include "../thread_safe_file_handler.h"
+#include "gtest/gtest.h"
+
+using std::filesystem::path;
+
+namespace server::file_handler::tests {
+namespace {
+
+/**
+ * @brief Manages a temp directory to use for testing.
+ */
+class TestDir {
+ public:
+  TestDir() {
+    // Create the test directory.
+    const path kTempDir = path("/tmp");
+
+    std::default_random_engine generator;
+    std::uniform_int_distribution<uint32_t> distribution(0, 1000);
+
+    std::stringstream dir_name;
+    dir_name << "test_" << time(nullptr) << "_" << distribution(generator);
+    test_dir_ = kTempDir / dir_name.str();
+    std::filesystem::create_directory(test_dir_);
+  }
+
+  ~TestDir() {
+    // Remove the test directory.
+    std::filesystem::remove_all(test_dir_);
+  }
+
+  /**
+   * @return The path to the testing directory.
+   */
+  [[nodiscard]] path Get() const { return test_dir_; }
+
+ private:
+  /// Directory to use for storing the tests.
+  path test_dir_;
+};
+
+/**
+ * @brief Encapsulates the FileAccessManagers we are using for these tests.
+ */
+struct AccessManagers {
+  std::shared_ptr<FileAccessManager> read_manager;
+  std::shared_ptr<FileAccessManager> write_manager;
+};
+
+/**
+ * @brief Creates FileAccessManagers to use for testing.
+ * @return The access managers it created.
+ */
+AccessManagers CreateAccessManagers() {
+  return {std::make_shared<FileAccessManager>(),
+          std::make_shared<FileAccessManager>()};
+}
+
+}  // namespace
+
+/**
+ * @test Tests that we can write a file and then read it back.
+ */
+TEST(FileHandler, PutGet) {
+  // Arrange.
+  TestDir test_dir;
+
+  // File to test with.
+  const path kTestFile = test_dir.Get() / "test_file.txt";
+  // Data to write.
+  const std::vector<uint8_t> kTestData = {1, 2, 3, 4, 5};
+
+  AccessManagers managers = CreateAccessManagers();
+  ThreadSafeFileHandler file_handler(managers.read_manager,
+                                     managers.write_manager);
+
+  // Act.
+  ASSERT_TRUE(file_handler.Put(kTestFile, kTestData));
+  const auto kGotData = file_handler.Get(kTestFile);
+
+  // Assert.
+  // It should have gotten the correct data.
+  EXPECT_EQ(kTestData, kGotData);
+  // The file should still be there.
+  EXPECT_TRUE(std::filesystem::exists(kTestFile));
+}
+
+/**
+ * @test Tests that we can write a file and then delete it.
+ */
+TEST(FileHandler, PutDelete) {
+  // Arrange.
+  TestDir test_dir;
+
+  // File to test with.
+  const path kTestFile = test_dir.Get() / "test_file.txt";
+
+  AccessManagers managers = CreateAccessManagers();
+  ThreadSafeFileHandler file_handler(managers.read_manager,
+                                     managers.write_manager);
+
+  // Act.
+  ASSERT_TRUE(file_handler.Put(kTestFile, {}));
+  const bool kDeleteSuccess = file_handler.Delete(kTestFile);
+
+  // Assert.
+  // Deletion should have succeeded.
+  EXPECT_TRUE(kDeleteSuccess);
+  // The file should no longer exist.
+  EXPECT_FALSE(std::filesystem::exists(kTestFile));
+}
+
+/**
+ * @test Tests that we can make a new directory.
+ */
+TEST(FileHandler, MakeDir) {
+  // Arrange.
+  TestDir test_dir;
+
+  // Test directory.
+  const path kTestDir = test_dir.Get() / "test_dir";
+
+  AccessManagers managers = CreateAccessManagers();
+  ThreadSafeFileHandler file_handler(managers.read_manager,
+                                     managers.write_manager);
+
+  // Act.
+  const bool kMakeDirResult = file_handler.MakeDir(kTestDir);
+
+  // Assert.
+  // It should have succeeded in creating the directory.
+  EXPECT_TRUE(kMakeDirResult);
+  // The directory should exist.
+  EXPECT_TRUE(std::filesystem::exists(kTestDir));
+}
+
+/**
+ * @test Tests that we can access two different files concurrently.
+ */
+TEST(FileHandler, PutGetConcurrentDifferentFiles) {
+  // Arrange.
+  TestDir test_dir;
+
+  // Files to test with.
+  const path kTestFile1 = test_dir.Get() / "test_file_1.txt";
+  const path kTestFile2 = test_dir.Get() / "test_file_2.txt";
+
+  // Data to write.
+  const std::vector<uint8_t> kTestData = {1, 2, 3, 4, 5};
+
+  AccessManagers managers = CreateAccessManagers();
+  ThreadSafeFileHandler file_handler1(managers.read_manager,
+                                      managers.write_manager);
+  ThreadSafeFileHandler file_handler2(managers.read_manager,
+                                      managers.write_manager);
+
+  // Act and assert.
+  std::thread thread1([&]() {
+    EXPECT_TRUE(file_handler1.Put(kTestFile1, kTestData));
+    const auto kGotData = file_handler1.Get(kTestFile1);
+
+    EXPECT_EQ(kTestData, kGotData);
+  });
+  std::thread thread2([&]() {
+    EXPECT_TRUE(file_handler2.Put(kTestFile2, kTestData));
+    const auto kGotData = file_handler2.Get(kTestFile2);
+
+    EXPECT_EQ(kTestData, kGotData);
+  });
+
+  thread1.join();
+  thread2.join();
+}
+
+/**
+ * @test Tests that we can access the same file concurrently.
+ */
+TEST(FileHandler, PutGetConcurrentSameFile) {
+  // Arrange.
+  TestDir test_dir;
+
+  // Files to test with.
+  const path kTestFile = test_dir.Get() / "test_file.txt";
+
+  // Data to write.
+  const std::vector<uint8_t> kTestData = {1, 2, 3, 4, 5};
+
+  AccessManagers managers = CreateAccessManagers();
+  ThreadSafeFileHandler file_handler1(managers.read_manager,
+                                      managers.write_manager);
+  ThreadSafeFileHandler file_handler2(managers.read_manager,
+                                      managers.write_manager);
+
+  // Act.
+  std::thread thread1([&]() {
+    EXPECT_TRUE(file_handler1.Put(kTestFile, kTestData));
+  });
+  std::thread thread2([&]() {
+    EXPECT_TRUE(file_handler2.Put(kTestFile, kTestData));
+  });
+
+  thread1.join();
+  thread2.join();
+
+  // Assert.
+  // One write should have cleanly overwritten the other, with no data
+  // duplication.
+  const auto kGotData = file_handler1.Get(kTestFile);
+  EXPECT_EQ(kTestData, kGotData);
+}
+
+}  // namespace server::file_handler::tests

--- a/project1/server/file_handler/thread_safe_file_handler.cpp
+++ b/project1/server/file_handler/thread_safe_file_handler.cpp
@@ -1,0 +1,52 @@
+#include "thread_safe_file_handler.h"
+
+#include <utility>
+
+#include "file_lock_guard.h"
+
+namespace server::file_handler {
+
+ThreadSafeFileHandler::ThreadSafeFileHandler(
+    std::shared_ptr<FileAccessManager> read_manager,
+    std::shared_ptr<FileAccessManager> write_manager)
+    : read_manager_(std::move(read_manager)),
+      write_manager_(std::move(write_manager)) {}
+
+std::vector<uint8_t> ThreadSafeFileHandler::Get(
+    const std::string& filename) const {
+  FileLockGuard read_lock(read_manager_.get(), ToAbsolute(filename));
+
+  return FileHandler::Get(filename);
+}
+
+bool ThreadSafeFileHandler::Put(const std::string& filename,
+                                const std::vector<uint8_t>& contents) {
+  const auto kPath = ToAbsolute(filename);
+  FileLockGuard read_lock(read_manager_.get(), kPath);
+  FileLockGuard write_lock(write_manager_.get(), kPath);
+
+  return FileHandler::Put(filename, contents);
+}
+
+bool ThreadSafeFileHandler::Delete(const std::string& filename) {
+  const auto kPath = ToAbsolute(filename);
+  FileLockGuard read_lock(read_manager_.get(), kPath);
+  FileLockGuard write_lock(write_manager_.get(), kPath);
+
+  return FileHandler::Delete(filename);
+}
+
+bool ThreadSafeFileHandler::MakeDir(const std::string& name) {
+  const auto kPath = ToAbsolute(name);
+  FileLockGuard read_lock(read_manager_.get(), kPath);
+  FileLockGuard write_lock(write_manager_.get(), kPath);
+
+  return FileHandler::MakeDir(name);
+}
+
+std::filesystem::path ThreadSafeFileHandler::ToAbsolute(
+    const std::filesystem::path& path) const {
+  return std::filesystem::path(GetCurrentDir()) / path;
+}
+
+}  // namespace server::file_handler

--- a/project1/server/file_handler/thread_safe_file_handler.h
+++ b/project1/server/file_handler/thread_safe_file_handler.h
@@ -1,0 +1,53 @@
+#ifndef PROJECT1_THREAD_SAFE_FILE_HANDLER_H
+#define PROJECT1_THREAD_SAFE_FILE_HANDLER_H
+
+#include <filesystem>
+#include <memory>
+#include <vector>
+
+#include "file_access_manager.h"
+#include "file_handler.h"
+
+namespace server::file_handler {
+
+/**
+ * @brief A thread-safe implementation of the file handler interface. It is
+ * suitable to have one instance per thread, and they will be synchronized
+ * globally.
+ */
+class ThreadSafeFileHandler : public FileHandler {
+ public:
+  /**
+   * @param read_manager Used for synchronizing access to files among multiple
+   *    instances in different threads.
+   */
+  explicit ThreadSafeFileHandler(
+      std::shared_ptr<FileAccessManager> read_manager,
+      std::shared_ptr<FileAccessManager> write_manager);
+
+  [[nodiscard]] std::vector<uint8_t> Get(
+      const std::string &filename) const final;
+  bool Put(const std::string &filename,
+           const std::vector<uint8_t> &contents) final;
+  bool Delete(const std::string &filename) final;
+  bool MakeDir(const std::string &name) final;
+
+ private:
+  /**
+   * @brief Computes an absolute path from this one based on the current
+   * directory.
+   * @param path The relative path to use.
+   * @return The absolute path.
+   */
+  [[nodiscard]] std::filesystem::path ToAbsolute(
+      const std::filesystem::path &path) const;
+
+  /// Synchronizes read access to files from multiple threads.
+  std::shared_ptr<FileAccessManager> read_manager_;
+  /// Synchronizes write access to files from multiple threads.
+  std::shared_ptr<FileAccessManager> write_manager_;
+};
+
+}  // namespace server::file_handler
+
+#endif  // PROJECT1_THREAD_SAFE_FILE_HANDLER_H


### PR DESCRIPTION
This also eliminates `FileHandler's` reliance on the current
directory, allowing it to safely be used with multiple concurrent
connections.

Also, I have added some tests for this functionality.