### PR TITLE
Add forking, terminate support to client

### DIFF
--- a/project1/client/CMakeLists.txt
+++ b/project1/client/CMakeLists.txt
@@ -1,7 +1,10 @@
-add_subdirectory(input_parser client_tasks)
-add_library(client_lib input_parser/input_parser.h client.cpp client.h client_tasks client_util.h)
-target_link_libraries(client_lib wire_protocol file_handler input_parser thread_pool)
-add_executable(client client_main.cpp client_util.h)
+add_subdirectory(input_parser)
+add_subdirectory(client_tasks)
+
+add_library(client_lib client.cpp)
+target_link_libraries(client_lib wire_protocol file_handler input_parser thread_pool
+                      client_tasks_lib)
+add_executable(client client_main.cpp)
 target_link_libraries(client client_lib)
 
 

--- a/project1/client/CMakeLists.txt
+++ b/project1/client/CMakeLists.txt
@@ -1,7 +1,7 @@
-add_subdirectory(input_parser)
-add_library(client_lib input_parser/input_parser.h client.cpp client.h)
-target_link_libraries(client_lib wire_protocol file_handler input_parser)
-add_executable(client client_main.cpp)
+add_subdirectory(input_parser client_tasks)
+add_library(client_lib input_parser/input_parser.h client.cpp client.h client_tasks client_util.h)
+target_link_libraries(client_lib wire_protocol file_handler input_parser thread_pool)
+add_executable(client client_main.cpp client_util.h)
 target_link_libraries(client client_lib)
 
 

--- a/project1/client/client.cpp
+++ b/project1/client/client.cpp
@@ -1,4 +1,6 @@
 #include "client.h"
+
+#include <memory>
 #include "client_tasks/terminate_task.h"
 #include "client_tasks/upload_task.h"
 #include "client_tasks/download_task.h"
@@ -122,7 +124,7 @@ void Client::FtpShell() {
     std::getline(std::cin, input);
 
     // determine command
-    auto ip_ = new InputParser(input);
+    std::unique_ptr<input_parser::InputParser> ip_ = std::make_unique<input_parser::InputParser>(input);
 
     // create & serialize request message for determined command
     r = ip_->CreateReq();
@@ -133,13 +135,11 @@ void Client::FtpShell() {
     if (r.has_terminate()) {
       auto terminate_task = std::make_shared<client_tasks::TerminateTask>(hostname_, tport_, r.terminate());
       pool.AddTask(terminate_task);
-      delete ip_;
       continue;
     }
     if (r.has_quit()) {
       // close socket connection
       close(client_fd_);
-      delete ip_;
       // exit loop, no need to send request
       connected_ = false;
       continue;
@@ -170,7 +170,6 @@ void Client::FtpShell() {
         pool.AddTask(get_task);
       }
     }
-    delete ip_;
   }
 }
 }  // namespace client

--- a/project1/client/client.cpp
+++ b/project1/client/client.cpp
@@ -114,7 +114,7 @@ bool Client::FtpShell() {
   thread_pool::ThreadPool pool;
 
   while (connected_) {
-    // will have to pay attention to formatting here when implementing Output()
+    // display myftp prompt
     std::cout << "\nmyftp> ";
 
     // reset input string

--- a/project1/client/client.cpp
+++ b/project1/client/client.cpp
@@ -151,6 +151,7 @@ bool Client::FtpShell() {
     WaitForMessage();
     HandleResponse();
     if (r.has_put()) {
+      // If put command, FileContents will have to be sent.
       auto contents = ip_->GetContentsMessage();
       wire_protocol::Serialize(contents, &outgoing_msg_buf_);
       if (!ip_->IsForking()) {
@@ -160,6 +161,7 @@ bool Client::FtpShell() {
         pool.AddTask(put_task);
       }
     } else if (r.has_get()) {
+      // If get command, FileContents will have to be received.
       if (!ip_->IsForking()) {
         WaitForMessage();
         client_util::SaveIncomingFile(parser_, ip_->GetFilename());

--- a/project1/client/client.cpp
+++ b/project1/client/client.cpp
@@ -124,11 +124,11 @@ void Client::FtpShell() {
     std::getline(std::cin, input);
 
     // determine command
-    std::unique_ptr<input_parser::InputParser> ip_ = std::make_unique<input_parser::InputParser>(input);
+    std::unique_ptr<input_parser::InputParser> ip = std::make_unique<input_parser::InputParser>(input);
 
     // create & serialize request message for determined command
-    r = ip_->CreateReq();
-    if (!ip_->IsValid()) {
+    r = ip->CreateReq();
+    if (!ip->IsValid()) {
       std::cout << "Invalid command, try again." << "\n";
       continue;
     }
@@ -150,9 +150,9 @@ void Client::FtpShell() {
     HandleResponse();
     if (r.has_put()) {
       // If put command, FileContents will have to be sent.
-      auto contents = ip_->GetContentsMessage();
+      auto contents = ip->GetContentsMessage();
       wire_protocol::Serialize(contents, &outgoing_msg_buf_);
-      if (!ip_->IsForking()) {
+      if (!ip->IsForking()) {
         SendReq();
       } else {
         auto put_task = std::make_shared<client_tasks::UploadTask>(client_fd_);
@@ -160,13 +160,14 @@ void Client::FtpShell() {
       }
     } else if (r.has_get()) {
       // If get command, FileContents will have to be received.
-      if (!ip_->IsForking()) {
+      if (!ip->IsForking()) {
         WaitForMessage();
         ftp_messages::FileContents contents;
         parser_.GetMessage(&contents);
-        client_util::SaveIncomingFile(contents.contents(), ip_->GetFilename());
+        client_util::SaveIncomingFile(contents.contents(), ip->GetFilename());
       } else {
-        auto get_task = std::make_shared<client_tasks::DownloadTask>(ip_->GetFilename(), kBufferSize, client_fd_);
+        auto get_task = std::make_shared<client_tasks::DownloadTask>(
+            ip->GetFilename(), kBufferSize, client_fd_);
         pool.AddTask(get_task);
       }
     }

--- a/project1/client/client.cpp
+++ b/project1/client/client.cpp
@@ -137,7 +137,7 @@ bool Client::FtpShell() {
       continue;
     }
     if (r.has_terminate()) {
-      auto terminate_task = std::make_shared<client_tasks::TerminateTask>(hostname_, tport_, r.mutable_terminate());
+      auto terminate_task = std::make_shared<client_tasks::TerminateTask>(hostname_, tport_, r.terminate());
       pool.AddTask(terminate_task);
       continue;
     }

--- a/project1/client/client.cpp
+++ b/project1/client/client.cpp
@@ -5,59 +5,15 @@
 
 #include <iostream>
 
-namespace {
-
-/**
- * @brief helper function for making a socket address structure
- *
- * @param port FTP server Port #
- */
-struct sockaddr_in MakeAddress(uint16_t port) {
-  struct sockaddr_in address {};
-  address.sin_family = AF_INET;
-  address.sin_addr.s_addr = INADDR_ANY;
-  address.sin_port = htons(port);
-
-  return address;
-}
-
-/**
- * @brief connects to socket
- * @param address socket address structure
- * @param hostname FTP server IP address
- * @return socket fd on success, -1 on failure
- *
- */
-int SetUpSocket(const struct sockaddr_in &address,
-                const std::string &hostname) {
-  int sock = 0;
-
-  if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-    perror("Socket creation error");
-    return -1;
-  }
-
-  if (inet_pton(AF_INET, hostname.c_str(),
-                (struct sockaddr *)&address.sin_addr) <= 0) {
-    perror("Invalid Address or Address not supported");
-    return -1;
-  }
-
-  if (connect(sock, (struct sockaddr *)&address, sizeof(address)) < 0) {
-    perror("Connection Failed");
-    return -1;
-  }
-
-  return sock;
-}
-}  // namespace
-
 namespace client {
 
 using client::input_parser::InputParser;
 
-bool Client::Connect(const std::string &hostname, uint16_t port) {
-  client_fd_ = SetUpSocket(MakeAddress(port), hostname);
+bool Client::Connect(const std::string &hostname, uint16_t nport, uint16_t tport) {
+  client_fd_ = client_util::SetUpSocket(client_util::MakeAddress(nport), hostname);
+  hostname_ = hostname;
+  nport_ = nport;
+  tport_ = tport;
   connected_ = true;
   return connected_;
 }

--- a/project1/client/client.h
+++ b/project1/client/client.h
@@ -45,20 +45,15 @@ class Client {
   bool SendReq();
 
   /**
-   * @brief expects a response message from socket, stores message in parser
-   * @return true on response received, false otherwise
+   * @brief expects a message from socket, stores message in parser
+   * @return true on message received, false otherwise
    */
-  bool WaitForResponse();
+  bool WaitForMessage();
 
   /**
    * @brief extracts relevant information to be displayed to user from response
    */
   void HandleResponse();
-
-  /**
-   * @brief handles extracting the contents from a FileContents message
-   */
-  void HandleFileContents();
 
  private:
   /**
@@ -91,11 +86,8 @@ class Client {
   // response info to be formatted and outputted
   std::string output_;
 
-  // parser for handling Responses
-  wire_protocol::MessageParser<ftp_messages::Response> response_parser_;
-
-  // parser for handling Contents
-  wire_protocol::MessageParser<ftp_messages::FileContents> file_parser_;
+  // parser for handling messages
+  wire_protocol::MessageParser<google::protobuf::Message> parser_;
 
   // parser for user input
   client::input_parser::InputParser *ip_;

--- a/project1/client/client.h
+++ b/project1/client/client.h
@@ -9,6 +9,7 @@
 #include "../server/file_handler/file_handler.h"
 #include "ftp_messages.pb.h"
 #include "input_parser/input_parser.h"
+#include "client_util.h"
 
 namespace client {
 

--- a/project1/client/client.h
+++ b/project1/client/client.h
@@ -5,88 +5,101 @@
 #define PROJECT1_CLIENT_H
 
 #include <cstdint>
-#include "../wire_protocol/wire_protocol.h"
+
 #include "../server/file_handler/file_handler.h"
+#include "../wire_protocol/wire_protocol.h"
 #include "ftp_messages.pb.h"
 #include "input_parser/input_parser.h"
 #include "client_util.h"
 
 namespace client {
 
-    /**
-     * @brief FTP Client. Contains logic for connecting to server, sending requests, outputting responses,
-     * and shell continuity.
-     *
-     */
-    class Client {
-    public:
+/**
+ * @brief FTP Client. Contains logic for connecting to server, sending requests,
+ * outputting responses, and shell continuity.
+ *
+ */
+class Client {
+ public:
+  /**
+   * @brief The shell logic.
+   *
+   * @return True when user properly quits
+   *
+   * @note will never return false.
+   */
+  bool FtpShell();
 
-        /**
-         * @brief The shell logic.
-         *
-         * @return True when user properly quits
-         *
-         * @note will never return false.
-         */
-        bool FtpShell();
+  /**
+   *
+   * @param hostname the ip address of the FTP server
+   * @param port the port the FTP server is binded to
+   * @return true on success, false on failure
+   */
+  bool Connect(const std::string &hostname, uint16_t nport, uint16_t tport);
 
-        /**
-         *
-         * @param hostname the ip address of the FTP server
-         * @param port the port the FTP server is binded to
-         * @return true on success, false on failure
-         */
-        bool Connect(const std::string &hostname, uint16_t port);
+  /**
+   * @brief sends the serialized message via a socket
+   * @return true on success, false on failure
+   */
+  bool SendReq();
 
+  /**
+   * @brief expects a response message from socket, stores message in parser
+   * @return true on response received, false otherwise
+   */
+  bool WaitForResponse();
 
-        /**
-         * @brief sends the serialized message via a socket
-         * @return true on success, false on failure
-         */
-        bool SendReq();
+  /**
+   * @brief extracts relevant information to be displayed to user from response
+   */
+  void HandleResponse();
 
-        /**
-         * @brief expects a response message from socket, stores message in parser
-         * @return true on response received, false otherwise
-         */
-        bool WaitForResponse();
+  /**
+   * @brief handles extracting the contents from a FileContents message
+   */
+  void HandleFileContents();
 
-        /**
-         * @brief extracts relevant information to be displayed to user from response
-         */
-        void HandleResponse();
+ private:
+  /**
+   * @brief Handles output formatting for responses
+   */
+  void Output();
 
-    private:
+  // tracking connection status
+  bool connected_;
 
-        /**
-         * @brief Handles output formatting for responses
-         */
-        void Output();
+  // buffer that stores serialized data to be sent to and received from server
+  std::vector<uint8_t> outgoing_msg_buf_{};
+  std::vector<uint8_t> incoming_msg_buf_{};
 
-        //tracking connection status
-        bool connected_;
+  // buffer size for client.
+  static constexpr size_t kBufferSize = 4096;
 
-        //buffer that stores serialized data to be sent to and received from server
-        std::vector<uint8_t> outgoing_msg_buf_{};
-        std::vector<uint8_t> incoming_msg_buf_{};
+  // hostname of the server
+  std::string hostname_;
 
-        //buffer size for client.
-        static constexpr size_t kBufferSize = 4096;
+  // client port
+  uint16_t nport_;
 
-        //client socket fd
-        int client_fd_;
+  // terminate port;
+  uint16_t tport_;
 
-        //response info to be formatted and outputted
-        std::string output_;
+  // client socket fd
+  int client_fd_;
 
-        //parser for handling messages
-        wire_protocol::MessageParser<ftp_messages::Response> parser_;
+  // response info to be formatted and outputted
+  std::string output_;
 
-        //parser for user input
-        client::input_parser::InputParser *ip_;
+  // parser for handling Responses
+  wire_protocol::MessageParser<ftp_messages::Response> response_parser_;
 
+  // parser for handling Contents
+  wire_protocol::MessageParser<ftp_messages::FileContents> file_parser_;
 
-    };
-}
+  // parser for user input
+  client::input_parser::InputParser *ip_;
+};
+}  // namespace client
 
-#endif //PROJECT1_CLIENT_H
+#endif  // PROJECT1_CLIENT_H

--- a/project1/client/client.h
+++ b/project1/client/client.h
@@ -62,32 +62,34 @@ class Client {
    */
   void Output();
 
-  // tracking connection status
+  /// tracking connection status
   bool connected_;
 
-  // buffer that stores serialized data to be sent to and received from server
+  /// buffer that stores serialized data to be sent to the server
   std::vector<uint8_t> outgoing_msg_buf_{};
+
+  /// buffer that stores serialized data to be received from the server
   std::vector<uint8_t> incoming_msg_buf_{};
 
-  // buffer size for client.
+  /// buffer size for client.
   static constexpr size_t kBufferSize = 4096;
 
-  // hostname of the server
+  /// hostname of the server
   std::string hostname_;
 
-  // client port
+  /// client port
   uint16_t nport_;
 
-  // terminate port;
+  /// terminate port;
   uint16_t tport_;
 
-  // client socket fd
+  /// client socket fd
   int client_fd_;
 
-  // response info to be formatted and outputted
+  /// response info to be formatted and outputted
   std::string output_;
 
-  // parser for handling messages
+  /// parser for handling messages
   wire_protocol::MessageParser<google::protobuf::Message> parser_;
 };
 }  // namespace client

--- a/project1/client/client.h
+++ b/project1/client/client.h
@@ -28,12 +28,13 @@ class Client {
    *
    * @note will never return false.
    */
-  bool FtpShell();
+  void FtpShell();
 
   /**
    *
    * @param hostname the ip address of the FTP server
-   * @param port the port the FTP server is binded to
+   * @param nport the port the FTP server listens to for various requests
+   * @param tport the port the FTP server listens to for termination requests
    * @return true on success, false on failure
    */
   bool Connect(const std::string &hostname, uint16_t nport, uint16_t tport);
@@ -88,9 +89,6 @@ class Client {
 
   // parser for handling messages
   wire_protocol::MessageParser<google::protobuf::Message> parser_;
-
-  // parser for user input
-  client::input_parser::InputParser *ip_;
 };
 }  // namespace client
 

--- a/project1/client/client_main.cpp
+++ b/project1/client/client_main.cpp
@@ -5,8 +5,8 @@
 #include "client.h"
 
 int main(int argc, const char **argv) {
-  if (argc != 3) {
-    std::cout << "\nIncorrect # of inputs. Server IP address & Port # expected";
+  if (argc != 4) {
+    std::cout << "\nIncorrect # of inputs. Server IP address, Command Port #, and Terminate Port # expected";
     return 1;
   }
   client::Client ftp_client;

--- a/project1/client/client_main.cpp
+++ b/project1/client/client_main.cpp
@@ -18,7 +18,10 @@ int main(int argc, const char **argv) {
   const auto tPort = strtol(argv[3], nullptr, 10);
 
   // first program argument should be the server IP address
-  ftp_client.Connect(argv[1], nPort, tPort);
+  if (!ftp_client.Connect(argv[1], nPort, tPort)) {
+    std::cout << "Failed to connect to " << argv[1] << ":" << nPort;
+    return 1;
+  }
 
   // spawn the shell
   ftp_client.FtpShell();

--- a/project1/client/client_main.cpp
+++ b/project1/client/client_main.cpp
@@ -2,31 +2,25 @@
  * @brief Entry point for the FTP client.
  */
 
-
 #include "client.h"
-#include "input_parser/input_parser.h"
-
-#define PORT 8080
-
 
 int main(int argc, const char **argv) {
+  if (argc != 3) {
+    std::cout << "\nIncorrect # of inputs. Server IP address & Port # expected";
+    return 1;
+  }
+  client::Client ftp_client;
 
-    if (argc != 3) {
-        std::cout << "\nIncorrect # of inputs. Server IP address & Port # expected";
-        return 1;
-    }
-    client::Client ftp_client;
+  // second program argument should be the command port #
+  const auto nPort = strtol(argv[2], nullptr, 10);
 
-    //second program argument should be the server port #
-    const auto kPort = strtol(argv[2], nullptr, 10);
+  // third program argument should be the terminate port #
+  const auto tPort = strtol(argv[3], nullptr, 10);
 
-    //first program argument should be the server IP address
-    ftp_client.Connect(argv[1], kPort);
+  // first program argument should be the server IP address
+  ftp_client.Connect(argv[1], nPort, tPort);
 
-    //spawn the shell
-    ftp_client.FtpShell();
-    return 0;
+  // spawn the shell
+  ftp_client.FtpShell();
+  return 0;
 }
-
-
-

--- a/project1/client/client_tasks/CMakeLists.txt
+++ b/project1/client/client_tasks/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_library(client_tasks_lib)
-target_link_libraries(client_tasks_lib thread_pool)
+add_library(client_tasks_lib terminate_task.cpp)
+target_link_libraries(client_tasks_lib thread_pool wire_protocol)

--- a/project1/client/client_tasks/CMakeLists.txt
+++ b/project1/client/client_tasks/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_library(client_tasks_lib terminate_task.cpp)
+add_library(client_tasks_lib terminate_task.cpp upload_task.cpp download_task.cpp)
 target_link_libraries(client_tasks_lib thread_pool wire_protocol)

--- a/project1/client/client_tasks/CMakeLists.txt
+++ b/project1/client/client_tasks/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_library(client_tasks_lib)
+target_link_libraries(client_tasks_lib thread_pool)

--- a/project1/client/client_tasks/download_task.cpp
+++ b/project1/client/client_tasks/download_task.cpp
@@ -1,0 +1,18 @@
+#include "download_task.h"
+
+namespace client_tasks {
+thread_pool::Task::Status DownloadTask::RunAtomic() {
+  while(!parser_.HasCompleteMessage()) {
+    incoming_file_buf_.resize(buffer_size_);
+    recv(client_fd_, incoming_file_buf_.data(), buffer_size_, 0);
+    incoming_file_buf_.resize(buffer_size_);
+    parser_.AddNewData(incoming_file_buf_);
+  }
+  client_util::SaveIncomingFile(parser_, filename_);
+  return thread_pool::Task::Status::DONE;
+}
+
+void DownloadTask::CleanUp() {
+  incoming_file_buf_.clear();
+}
+}

--- a/project1/client/client_tasks/download_task.cpp
+++ b/project1/client/client_tasks/download_task.cpp
@@ -1,7 +1,7 @@
 #include "download_task.h"
 
 namespace client_tasks {
-DownloadTask::DownloadTask(const std::string &filename, size_t buf_size,
+DownloadTask::DownloadTask(std::string filename, size_t buf_size,
                            int client_fd) : filename_(filename), client_fd_(client_fd), buffer_size_(buf_size) {};
 thread_pool::Task::Status DownloadTask::RunAtomic() {
   while(!parser_.HasCompleteMessage()) {

--- a/project1/client/client_tasks/download_task.cpp
+++ b/project1/client/client_tasks/download_task.cpp
@@ -4,11 +4,17 @@ namespace client_tasks {
 thread_pool::Task::Status DownloadTask::RunAtomic() {
   while(!parser_.HasCompleteMessage()) {
     incoming_file_buf_.resize(buffer_size_);
-    recv(client_fd_, incoming_file_buf_.data(), buffer_size_, 0);
-    incoming_file_buf_.resize(buffer_size_);
+    const auto bytes_read =
+        recv(client_fd_, incoming_file_buf_.data(), buffer_size_, 0);
+    if (bytes_read < 1) {
+      perror("Connection error.");
+    }
+    incoming_file_buf_.resize(bytes_read);
     parser_.AddNewData(incoming_file_buf_);
   }
-  client_util::SaveIncomingFile(parser_, filename_);
+  ftp_messages::FileContents contents;
+  parser_.GetMessage(&contents);
+  client_util::SaveIncomingFile(contents.contents(), filename_);
   return thread_pool::Task::Status::DONE;
 }
 

--- a/project1/client/client_tasks/download_task.cpp
+++ b/project1/client/client_tasks/download_task.cpp
@@ -2,11 +2,7 @@
 
 namespace client_tasks {
 DownloadTask::DownloadTask(const std::string &filename, size_t buf_size,
-                           int client_fd) {
-  filename_ = filename;
-  buffer_size_ = buf_size;
-  client_fd_ = client_fd;
-}
+                           int client_fd) : filename_(filename), client_fd_(client_fd), buffer_size_(buf_size) {};
 thread_pool::Task::Status DownloadTask::RunAtomic() {
   while(!parser_.HasCompleteMessage()) {
     incoming_file_buf_.resize(buffer_size_);

--- a/project1/client/client_tasks/download_task.cpp
+++ b/project1/client/client_tasks/download_task.cpp
@@ -1,6 +1,12 @@
 #include "download_task.h"
 
 namespace client_tasks {
+DownloadTask::DownloadTask(const std::string &filename, size_t buf_size,
+                           int client_fd) {
+  filename_ = filename;
+  buffer_size_ = buf_size;
+  client_fd_ = client_fd;
+}
 thread_pool::Task::Status DownloadTask::RunAtomic() {
   while(!parser_.HasCompleteMessage()) {
     incoming_file_buf_.resize(buffer_size_);

--- a/project1/client/client_tasks/download_task.h
+++ b/project1/client/client_tasks/download_task.h
@@ -1,0 +1,34 @@
+#ifndef PROJECT1_DOWNLOAD_TASK_H
+#define PROJECT1_DOWNLOAD_TASK_H
+
+#include "../../thread_pool/task.h"
+#include "../../wire_protocol/wire_protocol.h"
+#include "../client_util.h"
+
+namespace client_tasks {
+class DownloadTask : public thread_pool::Task {
+ public:
+  DownloadTask(const std::string& filename, std::vector<uint8_t> &incoming_buf,
+               size_t buf_size, int client_fd,
+               wire_protocol::MessageParser<google::protobuf::Message> &parser
+               ) {
+    filename_ = filename;
+    incoming_file_buf_ = incoming_buf;
+    buffer_size_ = buf_size;
+    client_fd_ = client_fd;
+    parser_ = parser;
+  }
+
+  Status RunAtomic() override;
+
+  void CleanUp() override;
+
+ protected:
+  std::string filename_{};
+  std::vector<uint8_t> incoming_file_buf_{};
+  int client_fd_;
+  size_t buffer_size_;
+  wire_protocol::MessageParser<google::protobuf::Message> parser_;
+};
+}
+#endif  // PROJECT1_DOWNLOAD_TASK_H

--- a/project1/client/client_tasks/download_task.h
+++ b/project1/client/client_tasks/download_task.h
@@ -12,6 +12,11 @@
 namespace client_tasks {
 class DownloadTask : public thread_pool::Task {
  public:
+  /**
+   * @param filename the name of the file to be saved
+   * @param buf_size the size of the buffer defined by client
+   * @param client_fd the socket to retreive the FileContents message
+   */
   DownloadTask(const std::string& filename, size_t buf_size, int client_fd);
 
   Status RunAtomic() override;

--- a/project1/client/client_tasks/download_task.h
+++ b/project1/client/client_tasks/download_task.h
@@ -12,11 +12,7 @@
 namespace client_tasks {
 class DownloadTask : public thread_pool::Task {
  public:
-  DownloadTask(const std::string& filename, size_t buf_size, int client_fd) {
-    filename_ = filename;
-    buffer_size_ = buf_size;
-    client_fd_ = client_fd;
-  }
+  DownloadTask(const std::string& filename, size_t buf_size, int client_fd);
 
   Status RunAtomic() override;
 
@@ -24,19 +20,19 @@ class DownloadTask : public thread_pool::Task {
 
  protected:
 
-  // the name of the file to be retreived
+  /// the name of the file to be retreived
   std::string filename_{};
 
-  // incoming buffer that stores serialized data to be received from the server
+  /// incoming buffer that stores serialized data to be received from the server
   std::vector<uint8_t> incoming_file_buf_{};
 
-  // client socket
+  /// client socket
   int client_fd_;
 
-  // buffer size, provided by client
+  /// buffer size, provided by client
   size_t buffer_size_;
 
-  // parser used to parse incoming FileContents messages
+  /// parser used to parse incoming FileContents messages
   wire_protocol::MessageParser<ftp_messages::FileContents> parser_;
 };
 }

--- a/project1/client/client_tasks/download_task.h
+++ b/project1/client/client_tasks/download_task.h
@@ -1,3 +1,7 @@
+/**
+ * @file Task for downloading a FileContents message asynchronously
+ */
+
 #ifndef PROJECT1_DOWNLOAD_TASK_H
 #define PROJECT1_DOWNLOAD_TASK_H
 
@@ -8,15 +12,10 @@
 namespace client_tasks {
 class DownloadTask : public thread_pool::Task {
  public:
-  DownloadTask(const std::string& filename, std::vector<uint8_t> &incoming_buf,
-               size_t buf_size, int client_fd,
-               wire_protocol::MessageParser<google::protobuf::Message> &parser
-               ) {
+  DownloadTask(const std::string& filename, size_t buf_size, int client_fd) {
     filename_ = filename;
-    incoming_file_buf_ = incoming_buf;
     buffer_size_ = buf_size;
     client_fd_ = client_fd;
-    parser_ = parser;
   }
 
   Status RunAtomic() override;
@@ -38,7 +37,7 @@ class DownloadTask : public thread_pool::Task {
   size_t buffer_size_;
 
   // parser used to parse incoming FileContents messages
-  wire_protocol::MessageParser<google::protobuf::Message> parser_;
+  wire_protocol::MessageParser<ftp_messages::FileContents> parser_;
 };
 }
 #endif  // PROJECT1_DOWNLOAD_TASK_H

--- a/project1/client/client_tasks/download_task.h
+++ b/project1/client/client_tasks/download_task.h
@@ -17,7 +17,7 @@ class DownloadTask : public thread_pool::Task {
    * @param buf_size the size of the buffer defined by client
    * @param client_fd the socket to retreive the FileContents message
    */
-  DownloadTask(const std::string& filename, size_t buf_size, int client_fd);
+  DownloadTask(std::string filename, size_t buf_size, int client_fd);
 
   Status RunAtomic() override;
 

--- a/project1/client/client_tasks/download_task.h
+++ b/project1/client/client_tasks/download_task.h
@@ -24,10 +24,20 @@ class DownloadTask : public thread_pool::Task {
   void CleanUp() override;
 
  protected:
+
+  // the name of the file to be retreived
   std::string filename_{};
+
+  // incoming buffer that stores serialized data to be received from the server
   std::vector<uint8_t> incoming_file_buf_{};
+
+  // client socket
   int client_fd_;
+
+  // buffer size, provided by client
   size_t buffer_size_;
+
+  // parser used to parse incoming FileContents messages
   wire_protocol::MessageParser<google::protobuf::Message> parser_;
 };
 }

--- a/project1/client/client_tasks/terminate_task.cpp
+++ b/project1/client/client_tasks/terminate_task.cpp
@@ -1,8 +1,4 @@
 #include "terminate_task.h"
-#include "../client_util.h"
-
-#include <sys/socket.h>
-#include <unistd.h>
 
 namespace client_tasks {
 thread_pool::Task::Status TerminateTask::SetUp() {

--- a/project1/client/client_tasks/terminate_task.cpp
+++ b/project1/client/client_tasks/terminate_task.cpp
@@ -1,11 +1,10 @@
 #include "terminate_task.h"
 
 namespace client_tasks {
-TerminateTask::TerminateTask(const std::string &address, uint16_t port, ftp_messages::TerminateRequest terminate_req) {
-  address_ = address;
-  port_ = port;
-  terminate_req_ = std::move(terminate_req);
-}
+TerminateTask::TerminateTask(const std::string &address, uint16_t port,
+                             ftp_messages::TerminateRequest terminate_req)
+    : address_(address), port_(port), terminate_req_(std::move(terminate_req)) {};
+
 thread_pool::Task::Status TerminateTask::SetUp() {
   socket_ = client_util::SetUpSocket( client_util::MakeAddress(port_), address_);
   return thread_pool::Task::Status::RUNNING;

--- a/project1/client/client_tasks/terminate_task.cpp
+++ b/project1/client/client_tasks/terminate_task.cpp
@@ -2,6 +2,7 @@
 #include "../client_util.h"
 
 #include <sys/socket.h>
+#include <unistd.h>
 
 namespace client_tasks {
 thread_pool::Task::Status TerminateTask::SetUp() {
@@ -18,8 +19,7 @@ thread_pool::Task::Status TerminateTask::RunAtomic() {
   outgoing_terminate_buf_.clear();
   return thread_pool::Task::Status::RUNNING;
 }
-thread_pool::Task::Status TerminateTask::CleanUp() {
+void TerminateTask::CleanUp() {
   close(socket_);
-  return thread_pool::Task::Status::DONE;
 }
 }

--- a/project1/client/client_tasks/terminate_task.cpp
+++ b/project1/client/client_tasks/terminate_task.cpp
@@ -1,0 +1,25 @@
+#include "terminate_task.h"
+#include "../client_util.h"
+
+#include <sys/socket.h>
+
+namespace client_tasks {
+thread_pool::Task::Status TerminateTask::SetUp() {
+  socket_ = client_util::SetUpSocket( client_util::MakeAddress(port_), address_);
+  return thread_pool::Task::Status::RUNNING;
+}
+thread_pool::Task::Status TerminateTask::RunAtomic() {
+  wire_protocol::Serialize(terminate_req_, &outgoing_terminate_buf_);
+  if (send(socket_, outgoing_terminate_buf_.data(),
+           outgoing_terminate_buf_.size(), 0) < 0) {
+    perror("Failed to send request");
+    return thread_pool::Task::Status::FAILED;
+  }
+  outgoing_terminate_buf_.clear();
+  return thread_pool::Task::Status::RUNNING;
+}
+thread_pool::Task::Status TerminateTask::CleanUp() {
+  close(socket_);
+  return thread_pool::Task::Status::DONE;
+}
+}

--- a/project1/client/client_tasks/terminate_task.cpp
+++ b/project1/client/client_tasks/terminate_task.cpp
@@ -13,7 +13,7 @@ thread_pool::Task::Status TerminateTask::RunAtomic() {
     return thread_pool::Task::Status::FAILED;
   }
   outgoing_terminate_buf_.clear();
-  return thread_pool::Task::Status::RUNNING;
+  return thread_pool::Task::Status::DONE;
 }
 void TerminateTask::CleanUp() {
   close(socket_);

--- a/project1/client/client_tasks/terminate_task.cpp
+++ b/project1/client/client_tasks/terminate_task.cpp
@@ -1,6 +1,11 @@
 #include "terminate_task.h"
 
 namespace client_tasks {
+TerminateTask::TerminateTask(const std::string &address, uint16_t port, ftp_messages::TerminateRequest terminate_req) {
+  address_ = address;
+  port_ = port;
+  terminate_req_ = std::move(terminate_req);
+}
 thread_pool::Task::Status TerminateTask::SetUp() {
   socket_ = client_util::SetUpSocket( client_util::MakeAddress(port_), address_);
   return thread_pool::Task::Status::RUNNING;

--- a/project1/client/client_tasks/terminate_task.h
+++ b/project1/client/client_tasks/terminate_task.h
@@ -18,11 +18,7 @@ namespace client_tasks {
 class TerminateTask : public thread_pool::Task {
  public:
   TerminateTask(const std::string &address, uint16_t port,
-                ftp_messages::TerminateRequest terminate_req) {
-    address_ = address;
-    port_ = port;
-    terminate_req_ = std::move(terminate_req);
-  }
+                ftp_messages::TerminateRequest terminate_req);
 
   thread_pool::Task::Status SetUp() override;
 
@@ -32,19 +28,19 @@ class TerminateTask : public thread_pool::Task {
 
  protected:
 
-  // outgoing buffer that stores serialized data to be sent to the server
+  /// outgoing buffer that stores serialized data to be sent to the server
   std::vector<uint8_t> outgoing_terminate_buf_{};
 
-  // address of the server
+  /// address of the server
   std::string address_{};
 
-  // termination port of the server
+  /// termination port of the server
   uint16_t port_;
 
-  // the encapsulated termination request
+  /// the encapsulated termination request
   ftp_messages::TerminateRequest terminate_req_;
 
-  // socket used to send the termination request
+  /// socket used to send the termination request
   int socket_{};
 
 };

--- a/project1/client/client_tasks/terminate_task.h
+++ b/project1/client/client_tasks/terminate_task.h
@@ -27,11 +27,22 @@ class TerminateTask : public thread_pool::Task {
   void CleanUp() override;
 
  protected:
+
+  // outgoing buffer that stores serialized data to be sent to the server
   std::vector<uint8_t> outgoing_terminate_buf_{};
+
+  // address of the server
   std::string address_{};
+
+  // termination port of the server
   uint16_t port_;
+
+  // the encapsulated termination request
   ftp_messages::TerminateRequest terminate_req_;
+
+  // socket used to send the termination request
   int socket_{};
+
 };
 }
 #endif  // PROJECT1_TERMINATE_TASK_H

--- a/project1/client/client_tasks/terminate_task.h
+++ b/project1/client/client_tasks/terminate_task.h
@@ -1,3 +1,7 @@
+/**
+ * @file Task to send a TerminateRequest message to server:tport
+ */
+
 #ifndef PROJECT1_TERMINATE_TASK_H
 #define PROJECT1_TERMINATE_TASK_H
 

--- a/project1/client/client_tasks/terminate_task.h
+++ b/project1/client/client_tasks/terminate_task.h
@@ -1,0 +1,33 @@
+#ifndef PROJECT1_TERMINATE_TASK_H
+#define PROJECT1_TERMINATE_TASK_H
+
+#include "../../thread_pool/thread_pool.h"
+#include "../../thread_pool/task.h"
+#include "../../wire_protocol/wire_protocol.h"
+#include "ftp_messages.pb.h"
+
+namespace client_tasks {
+class TerminateTask : public thread_pool::Task {
+ public:
+  TerminateTask(const std::string &address, uint16_t port,
+                ftp_messages::TerminateRequest *terminate_req) {
+    address_ = address;
+    port_ = port;
+    terminate_req_ = terminate_req;
+  }
+
+  thread_pool::Task::Status SetUp() override;
+
+  thread_pool::Task::Status RunAtomic() override;
+
+  void CleanUp() override;
+
+ protected:
+  std::vector<uint8_t> outgoing_terminate_buf_{};
+  std::string address_{};
+  uint16_t port_;
+  ftp_messages::TerminateRequest* terminate_req_;
+  int socket_{};
+};
+}
+#endif  // PROJECT1_TERMINATE_TASK_H

--- a/project1/client/client_tasks/terminate_task.h
+++ b/project1/client/client_tasks/terminate_task.h
@@ -1,12 +1,14 @@
 #ifndef PROJECT1_TERMINATE_TASK_H
 #define PROJECT1_TERMINATE_TASK_H
 
-#include "../../thread_pool/thread_pool.h"
 #include "../../thread_pool/task.h"
-
-#include <utility>
 #include "../../wire_protocol/wire_protocol.h"
 #include "ftp_messages.pb.h"
+#include "../client_util.h"
+
+#include <sys/socket.h>
+#include <utility>
+#include <unistd.h>
 
 namespace client_tasks {
 class TerminateTask : public thread_pool::Task {

--- a/project1/client/client_tasks/terminate_task.h
+++ b/project1/client/client_tasks/terminate_task.h
@@ -17,6 +17,11 @@
 namespace client_tasks {
 class TerminateTask : public thread_pool::Task {
  public:
+  /**
+   * @param address the address of the server
+   * @param port the terminate port of the server
+   * @param terminate_req the TerminateRequest to be sent
+   */
   TerminateTask(const std::string &address, uint16_t port,
                 ftp_messages::TerminateRequest terminate_req);
 

--- a/project1/client/client_tasks/terminate_task.h
+++ b/project1/client/client_tasks/terminate_task.h
@@ -3,6 +3,8 @@
 
 #include "../../thread_pool/thread_pool.h"
 #include "../../thread_pool/task.h"
+
+#include <utility>
 #include "../../wire_protocol/wire_protocol.h"
 #include "ftp_messages.pb.h"
 
@@ -10,10 +12,10 @@ namespace client_tasks {
 class TerminateTask : public thread_pool::Task {
  public:
   TerminateTask(const std::string &address, uint16_t port,
-                ftp_messages::TerminateRequest *terminate_req) {
+                ftp_messages::TerminateRequest terminate_req) {
     address_ = address;
     port_ = port;
-    terminate_req_ = terminate_req;
+    terminate_req_ = std::move(terminate_req);
   }
 
   thread_pool::Task::Status SetUp() override;
@@ -26,7 +28,7 @@ class TerminateTask : public thread_pool::Task {
   std::vector<uint8_t> outgoing_terminate_buf_{};
   std::string address_{};
   uint16_t port_;
-  ftp_messages::TerminateRequest* terminate_req_;
+  ftp_messages::TerminateRequest terminate_req_;
   int socket_{};
 };
 }

--- a/project1/client/client_tasks/upload_task.cpp
+++ b/project1/client/client_tasks/upload_task.cpp
@@ -1,6 +1,9 @@
 #include "upload_task.h"
 
 namespace client_tasks {
+UploadTask::UploadTask(int client_fd) {
+  client_fd_ = client_fd;
+}
 thread_pool::Task::Status UploadTask::RunAtomic() {
   if (send(client_fd_, outgoing_file_buf_.data(), outgoing_file_buf_.size(), 0) <
       0) {

--- a/project1/client/client_tasks/upload_task.cpp
+++ b/project1/client/client_tasks/upload_task.cpp
@@ -1,0 +1,15 @@
+#include "upload_task.h"
+
+namespace client_tasks {
+thread_pool::Task::Status UploadTask::RunAtomic() {
+  if (send(client_fd_, outgoing_file_buf_.data(), outgoing_file_buf_.size(), 0) <
+      0) {
+    perror("Failed to send request");
+    return thread_pool::Task::Status::FAILED;
+  }
+  return thread_pool::Task::Status::DONE;
+}
+void UploadTask::CleanUp() {
+  outgoing_file_buf_.clear();
+}
+}

--- a/project1/client/client_tasks/upload_task.cpp
+++ b/project1/client/client_tasks/upload_task.cpp
@@ -1,9 +1,7 @@
 #include "upload_task.h"
 
 namespace client_tasks {
-UploadTask::UploadTask(int client_fd) {
-  client_fd_ = client_fd;
-}
+UploadTask::UploadTask(int client_fd) : client_fd_(client_fd) {};
 thread_pool::Task::Status UploadTask::RunAtomic() {
   if (send(client_fd_, outgoing_file_buf_.data(), outgoing_file_buf_.size(), 0) <
       0) {

--- a/project1/client/client_tasks/upload_task.h
+++ b/project1/client/client_tasks/upload_task.h
@@ -17,8 +17,13 @@ class UploadTask : public thread_pool::Task {
   void CleanUp() override;
 
  protected:
+
+  // client socket
   int client_fd_;
+
+  // outgoing buffer that stores serialized data to be sent to the server
   std::vector<uint8_t> outgoing_file_buf_{};
+
 };
 }
 #endif  // PROJECT1_UPLOAD_TASK_H

--- a/project1/client/client_tasks/upload_task.h
+++ b/project1/client/client_tasks/upload_task.h
@@ -1,3 +1,7 @@
+/**
+ * @file Task to upload a file to the server asynchronously
+ */
+
 #ifndef PROJECT1_UPLOAD_TASK_H
 #define PROJECT1_UPLOAD_TASK_H
 
@@ -8,9 +12,8 @@
 namespace client_tasks {
 class UploadTask : public thread_pool::Task {
  public:
-  UploadTask(int client_fd, std::vector<uint8_t> &outgoing_buf) {
+  UploadTask(int client_fd) {
     client_fd_ = client_fd;
-    outgoing_file_buf_ = outgoing_buf;
   }
   Status RunAtomic() override;
 

--- a/project1/client/client_tasks/upload_task.h
+++ b/project1/client/client_tasks/upload_task.h
@@ -1,0 +1,24 @@
+#ifndef PROJECT1_UPLOAD_TASK_H
+#define PROJECT1_UPLOAD_TASK_H
+
+#include "../../thread_pool/task.h"
+#include "../../wire_protocol/wire_protocol.h"
+#include "ftp_messages.pb.h"
+
+namespace client_tasks {
+class UploadTask : public thread_pool::Task {
+ public:
+  UploadTask(int client_fd, std::vector<uint8_t> &outgoing_buf) {
+    client_fd_ = client_fd;
+    outgoing_file_buf_ = outgoing_buf;
+  }
+  Status RunAtomic() override;
+
+  void CleanUp() override;
+
+ protected:
+  int client_fd_;
+  std::vector<uint8_t> outgoing_file_buf_{};
+};
+}
+#endif  // PROJECT1_UPLOAD_TASK_H

--- a/project1/client/client_tasks/upload_task.h
+++ b/project1/client/client_tasks/upload_task.h
@@ -12,19 +12,18 @@
 namespace client_tasks {
 class UploadTask : public thread_pool::Task {
  public:
-  UploadTask(int client_fd) {
-    client_fd_ = client_fd;
-  }
+  UploadTask(int client_fd);
+
   Status RunAtomic() override;
 
   void CleanUp() override;
 
  protected:
 
-  // client socket
+  /// client socket
   int client_fd_;
 
-  // outgoing buffer that stores serialized data to be sent to the server
+  /// outgoing buffer that stores serialized data to be sent to the server
   std::vector<uint8_t> outgoing_file_buf_{};
 
 };

--- a/project1/client/client_tasks/upload_task.h
+++ b/project1/client/client_tasks/upload_task.h
@@ -12,7 +12,10 @@
 namespace client_tasks {
 class UploadTask : public thread_pool::Task {
  public:
-  UploadTask(int client_fd);
+  /**
+   * @param client_fd The socket used to upload the FileContents
+   */
+  explicit UploadTask(int client_fd);
 
   Status RunAtomic() override;
 

--- a/project1/client/client_util.h
+++ b/project1/client/client_util.h
@@ -11,6 +11,8 @@
 #include "../wire_protocol/wire_protocol.h"
 
 namespace client_util {
+
+// utility function to make an address struct based on port
 inline struct sockaddr_in MakeAddress(uint16_t port) {
   struct sockaddr_in address {};
   address.sin_family = AF_INET;
@@ -19,6 +21,8 @@ inline struct sockaddr_in MakeAddress(uint16_t port) {
 
   return address;
 }
+
+// utility function to initialize a socket
 inline int SetUpSocket(const struct sockaddr_in &address,
                        const std::string &hostname) {
   int sock = 0;
@@ -41,6 +45,8 @@ inline int SetUpSocket(const struct sockaddr_in &address,
 
   return sock;
 }
+
+// utility function to write a file to the local system
 inline void SaveIncomingFile(
     wire_protocol::MessageParser<google::protobuf::Message> f_parser,
     const std::string& name) {

--- a/project1/client/client_util.h
+++ b/project1/client/client_util.h
@@ -47,14 +47,11 @@ inline int SetUpSocket(const struct sockaddr_in &address,
 }
 
 // utility function to write a file to the local system
-inline void SaveIncomingFile(
-    wire_protocol::MessageParser<google::protobuf::Message> f_parser,
-    const std::string& name) {
-  ftp_messages::FileContents contents;
-  f_parser.GetMessage(&contents);
+inline void SaveIncomingFile(const std::string &contents,
+                             const std::string &name) {
   std::ofstream new_file;
   new_file.open(name);
-  new_file << contents.contents();
+  new_file << contents;
 }
 }
 #endif  // PROJECT1_UTIL_H

--- a/project1/client/client_util.h
+++ b/project1/client/client_util.h
@@ -5,6 +5,11 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
+#include <fstream>
+
+#include "ftp_messages.pb.h"
+#include "../wire_protocol/wire_protocol.h"
+
 namespace client_util {
 inline struct sockaddr_in MakeAddress(uint16_t port) {
   struct sockaddr_in address {};
@@ -35,6 +40,15 @@ inline int SetUpSocket(const struct sockaddr_in &address,
   }
 
   return sock;
+}
+inline void SaveIncomingFile(
+    wire_protocol::MessageParser<google::protobuf::Message> f_parser,
+    const std::string& name) {
+  ftp_messages::FileContents contents;
+  f_parser.GetMessage(&contents);
+  std::ofstream new_file;
+  new_file.open(name);
+  new_file << contents.contents();
 }
 }
 #endif  // PROJECT1_UTIL_H

--- a/project1/client/client_util.h
+++ b/project1/client/client_util.h
@@ -1,0 +1,40 @@
+#ifndef PROJECT1_UTIL_H
+#define PROJECT1_UTIL_H
+#include <cstdint>
+#include <string>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+namespace client_util {
+inline struct sockaddr_in MakeAddress(uint16_t port) {
+  struct sockaddr_in address {};
+  address.sin_family = AF_INET;
+  address.sin_addr.s_addr = INADDR_ANY;
+  address.sin_port = htons(port);
+
+  return address;
+}
+inline int SetUpSocket(const struct sockaddr_in &address,
+                       const std::string &hostname) {
+  int sock = 0;
+
+  if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+    perror("Socket creation error");
+    return -1;
+  }
+
+  if (inet_pton(AF_INET, hostname.c_str(),
+                (struct sockaddr *)&address.sin_addr) <= 0) {
+    perror("Invalid Address or Address not supported");
+    return -1;
+  }
+
+  if (connect(sock, (struct sockaddr *)&address, sizeof(address)) < 0) {
+    perror("Connection Failed");
+    return -1;
+  }
+
+  return sock;
+}
+}
+#endif  // PROJECT1_UTIL_H

--- a/project1/client/input_parser/input_parser.h
+++ b/project1/client/input_parser/input_parser.h
@@ -40,18 +40,18 @@ class InputParser {
   /**
    * @return whether or not the root command was valid
    */
-   bool IsValid();
+  bool IsValid();
 
-   /**
-    * @return whether or not the user requested to fork the command
-    */
-    bool IsForking();
+  /**
+   * @return whether or not the user requested to fork the command
+   */
+  bool IsForking();
 
   /**
    * @brief gets the contents of a file
    * @return file contents message
    */
-   ftp_messages::FileContents GetContentsMessage();
+  ftp_messages::FileContents GetContentsMessage();
 
   /**
    * creates the request to be sent

--- a/project1/client/input_parser/input_parser.h
+++ b/project1/client/input_parser/input_parser.h
@@ -119,7 +119,7 @@ class InputParser {
       {"ls", LS},    {"cd", CD},     {"mkdir", MKDIR},
       {"pwd", PWD},  {"quit", QUIT}, {"terminate", TERMINATE}};
 
-  // information to be extracted from input
+  /// information to be extracted from input
   bool is_valid_;
   bool is_forking_;
   ReqType req_;

--- a/project1/client/input_parser/input_parser.h
+++ b/project1/client/input_parser/input_parser.h
@@ -15,92 +15,118 @@
 
 namespace client::input_parser {
 
-    /**
-     * @brief Assists in mapping input commands for FTP client to corresponding
-     * protobuf request.
-     *
-     */
-    class InputParser {
-    public:
-        enum ReqType {GETF, PUTF, DEL, LS, CD, MKDIR, PWD, QUIT};
-
-        /**
-         * @brief Initializes relevant info about this input command
-         * @param cmd the user input
-         * @note assumes correct syntax
-         */
-        InputParser(std::string& cmd);
-
-
-        /**
-         * @brief getter for filename
-         * @return the filename
-         */
-        std::string GetFilename();
-
-        /**
-         * creates the request to be sent
-         * @return
-         */
-        ftp_messages::Request CreateReq();
-
-
-    private:
 /**
-         * creates a get request
-         * @return the request
-         */
-        ftp_messages::Request CreateGetReq();
+ * @brief Assists in mapping input commands for FTP client to corresponding
+ * protobuf request.
+ *
+ */
+class InputParser {
+ public:
+  enum ReqType { GETF, PUTF, DEL, LS, CD, MKDIR, PWD, QUIT, TERMINATE };
 
-        /**
-         * creates a put request
-         * @return the request
-         */
-        ftp_messages::Request CreatePutReq();
+  /**
+   * @brief Initializes relevant info about this input command
+   * @param cmd the user input
+   * @note assumes correct syntax
+   */
+  InputParser(std::string& cmd);
 
-        /**
-         * creates a delete request
-         * @return the request
-         */
-        ftp_messages::Request CreateDelReq();
+  /**
+   * @brief getter for filename
+   * @return the filename
+   */
+  std::string GetFilename();
 
-        /**
-         * creates a list request
-         * @return the request
-         */
-        ftp_messages::Request CreateListReq();
+  /**
+   * @return whether or not the root command was valid
+   */
+   bool IsValid();
 
-        /**
-         * creates a cd request
-         * @return the request
-         */
-        ftp_messages::Request CreateCDReq();
+   /**
+    * @return whether or not the user requested to fork the command
+    */
+    bool IsForking();
 
-        /**
-         * creates a mkdir request
-         * @return the request
-         */
-        ftp_messages::Request CreateMkdirReq();
+  /**
+   * @brief gets the contents of a file
+   * @return file contents message
+   */
+   ftp_messages::FileContents GetContentsMessage();
 
-        /**
-         * creates a pwd request
-         * @return the request
-         */
-        ftp_messages::Request CreatePwdReq();
+  /**
+   * creates the request to be sent
+   * @return
+   */
+  ftp_messages::Request CreateReq();
 
-        /**
-         * creates a quit request
-         * @return the request
-         */
-        ftp_messages::Request CreateQuitReq();
+ private:
+  /**
+   * creates a get request
+   * @return the request
+   */
+  ftp_messages::Request CreateGetReq();
 
-        const std::array<std::string, 8> commands_ = {"get", "put", "delete", "ls", "cd", "mkdir", "pwd", "quit"};\
+  /**
+   * creates a put request
+   * @return the request
+   */
+  ftp_messages::Request CreatePutReq();
 
-        //information to be extracted from input
-        ReqType req_;
-        std::string fn_;
-        std::string dn_;
-        std::vector<uint8_t> contents_;
-    };
-};//namespace input_parser
-#endif //PROJECT1_INPUT_PARSER_H
+  /**
+   * creates a delete request
+   * @return the request
+   */
+  ftp_messages::Request CreateDelReq();
+
+  /**
+   * creates a list request
+   * @return the request
+   */
+  ftp_messages::Request CreateListReq();
+
+  /**
+   * creates a cd request
+   * @return the request
+   */
+  ftp_messages::Request CreateCdReq();
+
+  /**
+   * creates a mkdir request
+   * @return the request
+   */
+  ftp_messages::Request CreateMkdirReq();
+
+  /**
+   * creates a pwd request
+   * @return the request
+   */
+  ftp_messages::Request CreatePwdReq();
+
+  /**
+   * creates a quit request
+   * @return the request
+   */
+  ftp_messages::Request CreateQuitReq();
+
+  /**
+   * creates a terminate request
+   * @return the request
+   */
+  ftp_messages::Request CreateTerminateReq();
+
+  const std::map<std::string, ReqType> commands_ = {
+      {"get", GETF}, {"put", PUTF},  {"delete", DEL},
+      {"ls", LS},    {"cd", CD},     {"mkdir", MKDIR},
+      {"pwd", PWD},  {"quit", QUIT}, {"terminate", TERMINATE}};
+
+  // information to be extracted from input
+  bool is_valid_;
+  bool is_forking_;
+  ReqType req_;
+  std::string fn_;
+  std::string dn_;
+  std::string cid_;
+  std::vector<uint8_t> contents_;
+};
+};      // namespace client::input_parser
+#endif  // PROJECT1_INPUT_PARSER_H

--- a/project1/wire_protocol/proto/ftp_messages.proto
+++ b/project1/wire_protocol/proto/ftp_messages.proto
@@ -72,6 +72,12 @@ message FileContents {
   bytes contents = 1;
 }
 
+/// Request to terminate a previous command.
+message TerminateRequest {
+  /// The command to be terminated
+  string command_id = 1;
+}
+
 /**
  * @brief Captures all possible request types. This is so we can simply parse this
  * message type from the network and worry later about the exact request type.
@@ -86,6 +92,7 @@ message Request {
     MakeDirRequest make_dir = 6;
     PwdRequest pwd = 7;
     QuitRequest quit = 8;
+    TerminateRequest terminate = 9;
   }
 }
 


### PR DESCRIPTION
This adds forking support to the GET and PUT commands.

By default, the input parser will recognize any command as forking if the last word of the command is `&`. However, the client is only programmed to parse these commands as forked processes for GET and PUT commands.

Note: I am going to add logging support in a later commit, just want this out there for review.

Also, there may be unforeseen issues with how I handled passing variables off to the tasks, so please take specific note to that.