### PR TITLE
Add protobuf messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,3 +11,4 @@ include_directories(common)
 
 add_subdirectory(common)
 add_subdirectory(project1_2)
+add_subdirectory(project3)

--- a/project3/CMakeLists.txt
+++ b/project3/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(proto)

--- a/project3/proto/CMakeLists.txt
+++ b/project3/proto/CMakeLists.txt
@@ -1,0 +1,15 @@
+include(FindProtobuf)
+find_package(Protobuf REQUIRED)
+
+include_directories(${PROTOBUF_INCLUDE_DIR})
+PROTOBUF_GENERATE_CPP(PROTO_SRC PROTO_HEADER pub_sub_messages.proto)
+add_library(pub_sub_proto ${PROTO_HEADER} ${PROTO_SRC})
+# Instruct everything that links to this to also link to Protobuf.
+target_link_libraries(pub_sub_proto INTERFACE ${Protobuf_LIBRARIES})
+# Make sure everything that depends on this can find the headers.
+target_include_directories(pub_sub_proto INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
+
+# For Mac Users
+if (APPLE)
+    target_include_directories(pub_sub_proto INTERFACE "/usr/local/Cellar/protobuf/3.14.0/include")
+endif()

--- a/project3/proto/pub_sub_messages.proto
+++ b/project3/proto/pub_sub_messages.proto
@@ -1,0 +1,57 @@
+syntax = "proto3";
+
+package pub_sub_messages;
+
+/// Request sent by a participant to register with the coordinator.
+message Register {
+}
+
+/// Request sent by the coordinator upon successful registration.
+message RegistrationResponse {
+  /// Indicates the ID of this participant.
+  uint32 participant_id = 1;
+}
+
+/// Message sent by a participant to deregister with the coordinator.
+message Deregister {
+}
+
+/// Message sent by a participant to indicate that it is going offline.
+message Disconnect {
+}
+
+/// Message sent by a participant to indicate that it is coming back online.
+message Reconnect {
+}
+
+/// Message sent by a participant that will be sent out to the whole group.
+message SendMulticast {
+  /// The actual message contents.
+  string message = 1;
+}
+
+/**
+ * @brief Message sent by a coordinator to participants containing the data for a
+ * multicast message that has been received.
+ */
+message ForwardMulticast {
+  /// The actual message contents.
+  string message = 1;
+  /// The ID of the participant that this message originated from.
+  uint32 origin_id = 2;
+}
+
+/**
+ * @brief Encapsulates all messages that can be received by the coordinator. This is
+ * so we can simply parse this message type from the network and worry later about
+ * the actual message type.
+ */
+message CoordinatorMessage {
+  oneof messages {
+    Register register = 1;
+    Deregister deregister = 2;
+    Disconnect disconnect = 3;
+    Reconnect reconnect = 4;
+    SendMulticast send_multicast = 5;
+  }
+}


### PR DESCRIPTION
I'm still not entirely clear on whether the participants actually have to listen on a port as opposed to just connecting to an open port the coordinator and receiving messages that way. If so, this will need to be changed.