### PR TITLE
Add input_parser

### DIFF
--- a/project3/CMakeLists.txt
+++ b/project3/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(proto)
+add_subdirectory(participant)

--- a/project3/participant/CMakeLists.txt
+++ b/project3/participant/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(input_parser)

--- a/project3/participant/input_parser/CMakeLists.txt
+++ b/project3/participant/input_parser/CMakeLists.txt
@@ -1,3 +1,2 @@
-add_library(input_parser_p3 input_parser.h input_parser.cpp)
-set_target_properties(input_parser_p3 PROPERTIES LINKER_LANGUAGE CXX)
+add_library(input_parser_p3 input_parser.cpp)
 target_link_libraries(input_parser_p3 pub_sub_proto wire_protocol)

--- a/project3/participant/input_parser/CMakeLists.txt
+++ b/project3/participant/input_parser/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(input_parser_p3 input_parser.h input_parser.cpp)
+set_target_properties(input_parser_p3 PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(input_parser_p3 pub_sub_proto wire_protocol)

--- a/project3/participant/input_parser/input_parser.cpp
+++ b/project3/participant/input_parser/input_parser.cpp
@@ -3,11 +3,11 @@
 namespace participant::input_parser {
 
 InputParser::InputParser()
-    : reg_msg_{pub_sub_messages::Register()},
-      dereg_msg_{pub_sub_messages::Deregister()},
-      discon_msg_{pub_sub_messages::Disconnect()},
-      recon_msg_{pub_sub_messages::Reconnect()},
-      msend_msg_{pub_sub_messages::SendMulticast()},
+    : reg_msg_{},
+      dereg_msg_{},
+      discon_msg_{},
+      recon_msg_{},
+      msend_msg_{},
       multi_id_{0},
       is_valid_{true},
       req_{REG},

--- a/project3/participant/input_parser/input_parser.cpp
+++ b/project3/participant/input_parser/input_parser.cpp
@@ -3,7 +3,15 @@
 namespace participant::input_parser {
 
 InputParser::InputParser()
-    : multi_id_{0}, is_valid_{true}, req_{REG}, message_{} {}
+    : reg_msg_{pub_sub_messages::Register().New()},
+      dereg_msg_{pub_sub_messages::Deregister().New()},
+      discon_msg_{pub_sub_messages::Disconnect().New()},
+      recon_msg_{pub_sub_messages::Reconnect().New()},
+      msend_msg_{pub_sub_messages::SendMulticast().New()},
+      multi_id_{0},
+      is_valid_{true},
+      req_{REG},
+      message_{} {}
 
 void InputParser::Parse(std::string& cmd) {
   std::istringstream iss(cmd);
@@ -45,23 +53,18 @@ google::protobuf::Message* InputParser::CreateReq() {
   return nullptr;
 }
 pub_sub_messages::Register* InputParser::CreateRegMsg() {
-  reg_msg_ = pub_sub_messages::Register().New();
   return reg_msg_;
 }
 pub_sub_messages::Deregister* InputParser::CreateDeregMsg() {
-  dereg_msg_ = pub_sub_messages::Deregister().New();
   return dereg_msg_;
 }
 pub_sub_messages::Disconnect* InputParser::CreateDisconMsg() {
-  discon_msg_ = pub_sub_messages::Disconnect().New();
   return discon_msg_;
 }
 pub_sub_messages::Reconnect* InputParser::CreateReconMsg() {
-  recon_msg_ = pub_sub_messages::Reconnect().New();
   return recon_msg_;
 }
 pub_sub_messages::SendMulticast* InputParser::CreateMsendMsg() {
-  msend_msg_ = pub_sub_messages::SendMulticast().New();
   msend_msg_->set_message(message_);
   return msend_msg_;
 }

--- a/project3/participant/input_parser/input_parser.cpp
+++ b/project3/participant/input_parser/input_parser.cpp
@@ -1,0 +1,67 @@
+#include "input_parser.h"
+
+namespace participant::input_parser {
+
+InputParser::InputParser()
+    : multi_id_{0}, is_valid_{true}, req_{REG}, message_{} {}
+
+void InputParser::Parse(std::string& cmd) {
+  std::istringstream iss(cmd);
+  std::string word;
+  iss >> word;
+  auto itr = commands_.find(word);
+  is_valid_ = itr != commands_.end();
+  if (!is_valid_) {
+    return;
+  }
+  req_ = itr->second;
+  switch (req_) {
+    case MSEND:
+      std::getline(iss, message_);
+      break;
+    case REG:
+    case RECON:
+      iss >> multi_id_;
+      break;
+    case DISCON:
+    case DEREG:
+      break;
+  }
+}  // InputParser
+
+bool InputParser::IsValid() { return is_valid_; }
+
+google::protobuf::Message* InputParser::CreateReq() {
+  switch (req_) {
+    case REG:
+      return CreateRegMsg();
+    case DEREG:
+      return CreateDeregMsg();
+    case DISCON:
+      return CreateDisconMsg();
+    case RECON:
+      return CreateReconMsg();
+    case MSEND:
+      return CreateMsendMsg();
+  }
+  return nullptr;
+}
+pub_sub_messages::Register* InputParser::CreateRegMsg() {
+  return pub_sub_messages::Register().New();
+}
+pub_sub_messages::Deregister* InputParser::CreateDeregMsg() {
+  return pub_sub_messages::Deregister().New();
+}
+pub_sub_messages::Disconnect* InputParser::CreateDisconMsg() {
+  return pub_sub_messages::Disconnect().New();
+}
+pub_sub_messages::Reconnect* InputParser::CreateReconMsg() {
+  return pub_sub_messages::Reconnect().New();
+}
+pub_sub_messages::SendMulticast* InputParser::CreateMsendMsg() {
+  pub_sub_messages::SendMulticast* msg =
+      pub_sub_messages::SendMulticast().New();
+  msg->set_message(message_);
+  return msg;
+}
+}  // namespace participant::input_parser

--- a/project3/participant/input_parser/input_parser.cpp
+++ b/project3/participant/input_parser/input_parser.cpp
@@ -45,21 +45,24 @@ google::protobuf::Message* InputParser::CreateReq() {
   return nullptr;
 }
 pub_sub_messages::Register* InputParser::CreateRegMsg() {
-  return pub_sub_messages::Register().New();
+  reg_msg_ = pub_sub_messages::Register().New();
+  return reg_msg_;
 }
 pub_sub_messages::Deregister* InputParser::CreateDeregMsg() {
-  return pub_sub_messages::Deregister().New();
+  dereg_msg_ = pub_sub_messages::Deregister().New();
+  return dereg_msg_;
 }
 pub_sub_messages::Disconnect* InputParser::CreateDisconMsg() {
-  return pub_sub_messages::Disconnect().New();
+  discon_msg_ = pub_sub_messages::Disconnect().New();
+  return discon_msg_;
 }
 pub_sub_messages::Reconnect* InputParser::CreateReconMsg() {
-  return pub_sub_messages::Reconnect().New();
+  recon_msg_ = pub_sub_messages::Reconnect().New();
+  return recon_msg_;
 }
 pub_sub_messages::SendMulticast* InputParser::CreateMsendMsg() {
-  pub_sub_messages::SendMulticast* msg =
-      pub_sub_messages::SendMulticast().New();
-  msg->set_message(message_);
-  return msg;
+  msend_msg_ = pub_sub_messages::SendMulticast().New();
+  msend_msg_->set_message(message_);
+  return msend_msg_;
 }
 }  // namespace participant::input_parser

--- a/project3/participant/input_parser/input_parser.cpp
+++ b/project3/participant/input_parser/input_parser.cpp
@@ -3,11 +3,11 @@
 namespace participant::input_parser {
 
 InputParser::InputParser()
-    : reg_msg_{pub_sub_messages::Register().New()},
-      dereg_msg_{pub_sub_messages::Deregister().New()},
-      discon_msg_{pub_sub_messages::Disconnect().New()},
-      recon_msg_{pub_sub_messages::Reconnect().New()},
-      msend_msg_{pub_sub_messages::SendMulticast().New()},
+    : reg_msg_{pub_sub_messages::Register()},
+      dereg_msg_{pub_sub_messages::Deregister()},
+      discon_msg_{pub_sub_messages::Disconnect()},
+      recon_msg_{pub_sub_messages::Reconnect()},
+      msend_msg_{pub_sub_messages::SendMulticast()},
       multi_id_{0},
       is_valid_{true},
       req_{REG},
@@ -40,32 +40,17 @@ bool InputParser::IsValid() { return is_valid_; }
 google::protobuf::Message* InputParser::CreateReq() {
   switch (req_) {
     case REG:
-      return CreateRegMsg();
+      return &reg_msg_;
     case DEREG:
-      return CreateDeregMsg();
+      return &dereg_msg_;
     case DISCON:
-      return CreateDisconMsg();
+      return &discon_msg_;
     case RECON:
-      return CreateReconMsg();
+      return &recon_msg_;
     case MSEND:
-      return CreateMsendMsg();
+      msend_msg_.set_message(message_);
+      return &msend_msg_;
   }
   return nullptr;
-}
-pub_sub_messages::Register* InputParser::CreateRegMsg() {
-  return reg_msg_;
-}
-pub_sub_messages::Deregister* InputParser::CreateDeregMsg() {
-  return dereg_msg_;
-}
-pub_sub_messages::Disconnect* InputParser::CreateDisconMsg() {
-  return discon_msg_;
-}
-pub_sub_messages::Reconnect* InputParser::CreateReconMsg() {
-  return recon_msg_;
-}
-pub_sub_messages::SendMulticast* InputParser::CreateMsendMsg() {
-  msend_msg_->set_message(message_);
-  return msend_msg_;
 }
 }  // namespace participant::input_parser

--- a/project3/participant/input_parser/input_parser.cpp
+++ b/project3/participant/input_parser/input_parser.cpp
@@ -21,8 +21,6 @@ void InputParser::Parse(std::string& cmd) {
       break;
     case REG:
     case RECON:
-      iss >> multi_id_;
-      break;
     case DISCON:
     case DEREG:
       break;

--- a/project3/participant/input_parser/input_parser.h
+++ b/project3/participant/input_parser/input_parser.h
@@ -7,14 +7,10 @@
 
 #include <pub_sub_messages.pb.h>
 
-#include <array>
-#include <cstdint>
 #include <sstream>
 #include <string>
-#include <vector>
 
 #include "pub_sub_messages.pb.h"
-#include "wire_protocol/wire_protocol.h"
 
 namespace participant::input_parser {
 

--- a/project3/participant/input_parser/input_parser.h
+++ b/project3/participant/input_parser/input_parser.h
@@ -46,31 +46,6 @@ class InputParser {
   google::protobuf::Message* CreateReq();
 
  private:
-  /**
-   * creates a register message
-   */
-  pub_sub_messages::Register* CreateRegMsg();
-
-  /**
-   * creates a reregister message
-   */
-  pub_sub_messages::Deregister* CreateDeregMsg();
-
-  /**
-   * creates a disconnect message
-   */
-  pub_sub_messages::Disconnect* CreateDisconMsg();
-
-  /**
-   * creates a reconnect message
-   */
-  pub_sub_messages::Reconnect* CreateReconMsg();
-
-  /**
-   * creates a multicast send message
-   */
-  pub_sub_messages::SendMulticast* CreateMsendMsg();
-
   const std::map<std::string, MsgType> commands_ = {{"register", REG},
                                                     {"deregister", DEREG},
                                                     {"disconnect", DISCON},
@@ -78,11 +53,11 @@ class InputParser {
                                                     {"msend", MSEND}};
 
   /// messages having been parsed from input
-  pub_sub_messages::Register* reg_msg_;
-  pub_sub_messages::Deregister* dereg_msg_;
-  pub_sub_messages::Disconnect* discon_msg_;
-  pub_sub_messages::Reconnect* recon_msg_;
-  pub_sub_messages::SendMulticast* msend_msg_;
+  pub_sub_messages::Register reg_msg_;
+  pub_sub_messages::Deregister dereg_msg_;
+  pub_sub_messages::Disconnect discon_msg_;
+  pub_sub_messages::Reconnect recon_msg_;
+  pub_sub_messages::SendMulticast msend_msg_;
 
   /// information to be extracted from input
   int multi_id_;

--- a/project3/participant/input_parser/input_parser.h
+++ b/project3/participant/input_parser/input_parser.h
@@ -1,0 +1,91 @@
+/**
+ * @file Handles input parsing for the participant in Project 3
+ */
+
+#ifndef PROJECT3_INPUT_PARSER_H
+#define PROJECT3_INPUT_PARSER_H
+
+#include <pub_sub_messages.pb.h>
+
+#include <array>
+#include <cstdint>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "pub_sub_messages.pb.h"
+#include "wire_protocol/wire_protocol.h"
+
+namespace participant::input_parser {
+
+/**
+ * @brief Assists in mapping input commands for FTP client to corresponding
+ * protobuf request.
+ *
+ */
+class InputParser {
+ public:
+  enum MsgType { REG, DEREG, DISCON, RECON, MSEND };
+
+  /**
+   * @brief Initializes relevant info about this input command
+   * @param cmd the user input
+   */
+  InputParser();
+
+  /**
+   * @return whether or not the root command was valid
+   */
+  bool IsValid();
+
+  /**
+   * @param cmd the user input
+   */
+  void Parse(std::string& cmd);
+
+  /**
+   * creates the request to be sent
+   * @return
+   */
+  google::protobuf::Message* CreateReq();
+
+ private:
+  /**
+   * creates a register message
+   */
+  pub_sub_messages::Register* CreateRegMsg();
+
+  /**
+   * creates a reregister message
+   */
+  pub_sub_messages::Deregister* CreateDeregMsg();
+
+  /**
+   * creates a disconnect message
+   */
+  pub_sub_messages::Disconnect* CreateDisconMsg();
+
+  /**
+   * creates a reconnect message
+   */
+  pub_sub_messages::Reconnect* CreateReconMsg();
+
+  /**
+   * creates a multicast send message
+   */
+  pub_sub_messages::SendMulticast* CreateMsendMsg();
+
+  const std::map<std::string, MsgType> commands_ = {{"register", REG},
+                                                    {"deregister", DEREG},
+                                                    {"disconnect", DISCON},
+                                                    {"reconnect", RECON},
+                                                    {"msend", MSEND}};
+
+  /// information to be extracted from input
+  int multi_id_;
+  bool is_valid_;
+  MsgType req_;
+  std::string message_;
+};
+};      // namespace participant::input_parser
+#endif  // PROJECT3_INPUT_PARSER_H

--- a/project3/participant/input_parser/input_parser.h
+++ b/project3/participant/input_parser/input_parser.h
@@ -77,11 +77,18 @@ class InputParser {
                                                     {"reconnect", RECON},
                                                     {"msend", MSEND}};
 
+  /// messages having been parsed from input
+  pub_sub_messages::Register* reg_msg_;
+  pub_sub_messages::Deregister* dereg_msg_;
+  pub_sub_messages::Disconnect* discon_msg_;
+  pub_sub_messages::Reconnect* recon_msg_;
+  pub_sub_messages::SendMulticast* msend_msg_;
+
   /// information to be extracted from input
   int multi_id_;
   bool is_valid_;
   MsgType req_;
   std::string message_;
 };
-};      // namespace participant::input_parser
+}  // namespace participant::input_parser
 #endif  // PROJECT3_INPUT_PARSER_H

--- a/project3/participant/input_parser/input_parser.h
+++ b/project3/participant/input_parser/input_parser.h
@@ -53,11 +53,11 @@ class InputParser {
                                                     {"msend", MSEND}};
 
   /// messages having been parsed from input
-  pub_sub_messages::Register reg_msg_;
-  pub_sub_messages::Deregister dereg_msg_;
-  pub_sub_messages::Disconnect discon_msg_;
-  pub_sub_messages::Reconnect recon_msg_;
-  pub_sub_messages::SendMulticast msend_msg_;
+  pub_sub_messages::Register reg_msg_{};
+  pub_sub_messages::Deregister dereg_msg_{};
+  pub_sub_messages::Disconnect discon_msg_{};
+  pub_sub_messages::Reconnect recon_msg_{};
+  pub_sub_messages::SendMulticast msend_msg_{};
 
   /// information to be extracted from input
   int multi_id_;


### PR DESCRIPTION
This is a simple implementation of input parser for Project 3. One main change between this and the original input parser is that this will not need to be re-instantiated. Instead, there is a method to parse new input and the request will be re-evaluated each time a message is parsed.

Note: I wanted to avoid any null-related issues with class variables so I added them all in the initializer list. However, I am not sure if this was the proper way to do it here.