### PR TITLE
Add port_number to Register, Reconnect

### DIFF
--- a/project3/proto/pub_sub_messages.proto
+++ b/project3/proto/pub_sub_messages.proto
@@ -4,6 +4,8 @@ package pub_sub_messages;
 
 /// Request sent by a participant to register with the coordinator.
 message Register {
+  /// Port number to indicate the mutlicast receiever thread.
+  uint32 port_number = 1;
 }
 
 /// Request sent by the coordinator upon successful registration.
@@ -22,6 +24,8 @@ message Disconnect {
 
 /// Message sent by a participant to indicate that it is coming back online.
 message Reconnect {
+  /// Port number to indicate the mutlicast receiever thread.
+  uint32 port_number = 1;
 }
 
 /// Message sent by a participant that will be sent out to the whole group.


### PR DESCRIPTION
Adds the `port_number` parameter to the `Register` and `Reconnect` message.