### PR TITLE
Add tests for `MessageLog` class.

### DIFF
--- a/project3/coordinator/CMakeLists.txt
+++ b/project3/coordinator/CMakeLists.txt
@@ -1,2 +1,4 @@
+add_subdirectory(tests)
+
 add_library(coordinator connected_participants.cpp message_log.cpp registrar.cpp messenger.cpp messenger_manager.cpp)
 target_link_libraries(coordinator pub_sub_proto wire_protocol loguru)

--- a/project3/coordinator/tests/CMakeLists.txt
+++ b/project3/coordinator/tests/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(test_message_log test_message_log.cpp)
+target_link_libraries(test_message_log gtest_main coordinator)
+add_test(NAME test_message_log COMMAND test_message_log)

--- a/project3/coordinator/tests/test_message_log.cpp
+++ b/project3/coordinator/tests/test_message_log.cpp
@@ -1,0 +1,77 @@
+/**
+ * @file Tests for the `MessageLog` class.
+ */
+
+#include <chrono>
+
+#include "../message_log.h"
+#include "gtest/gtest.h"
+
+namespace coordinator::tests {
+namespace {
+
+/// Message retention threshold to use for testing.
+const MessageLog::Duration kRetentionThreshold = std::chrono::milliseconds(10);
+/// Test message to use for various functions.
+const MessageLog::Message kTestMessage{"hello",
+                                       std::chrono::steady_clock::now(), 42};
+
+}  // namespace
+
+/**
+ * @test Tests that message equality works correctly.
+ */
+TEST(MessageLog, MessageEquality) {
+  // Arrange.
+  MessageLog::Message message2 = kTestMessage;
+
+  // Act.
+  // They should compare as equal.
+  EXPECT_EQ(kTestMessage, message2);
+
+  // Modifying them should change that.
+  message2.msg = "goodbye";
+  // Have to do it this way because we technically don't implement operator!=.
+  EXPECT_FALSE(kTestMessage == message2);
+}
+
+/**
+ * @test Tests that message hashing works correctly.
+ */
+TEST(MessageLog, MessageHash) {
+  // Arrange.
+  MessageLog::Message message2 = kTestMessage;
+
+  // Act.
+  // The hashes should be the same.
+  EXPECT_EQ(MessageLog::Hash()(kTestMessage), MessageLog::Hash()(message2));
+
+  // Modifying them should change that.
+  message2.msg = "goodbye";
+  EXPECT_NE(MessageLog::Hash()(kTestMessage), MessageLog::Hash()(message2));
+}
+
+/**
+ * @test Tests that we can get missed messages.
+ */
+TEST(MessageLog, TestMissedMessages) {
+  // Arrange.
+  // Create an older message that should be dropped.
+  auto old_message = kTestMessage;
+  old_message.timestamp -= kRetentionThreshold * 2;
+
+  // Insert both messages.
+  MessageLog log(kRetentionThreshold);
+  log.Insert(kTestMessage);
+  log.Insert(old_message);
+
+  // Act.
+  auto missed_messages = log.GetMissedMessages(kTestMessage.timestamp);
+
+  // Assert.
+  // It should have gotten the new message but not the old one.
+  EXPECT_EQ(1U, missed_messages.size());
+  EXPECT_NE(missed_messages.find(kTestMessage), missed_messages.end());
+}
+
+}  // namespace coordinator::tests


### PR DESCRIPTION
This is part of a series of PRs where I write unit tests for project 3 functionality in the hopes of easing integration.