### PR TITLE
Enable timeouts for queue pops.

### DIFF
--- a/common/queue/CMakeLists.txt
+++ b/common/queue/CMakeLists.txt
@@ -1,1 +1,4 @@
 add_subdirectory(tests)
+
+add_library(queue INTERFACE)
+target_link_libraries(queue INTERFACE loguru)

--- a/common/queue/tests/CMakeLists.txt
+++ b/common/queue/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(test_queue test_queue.cpp)
-target_link_libraries(test_queue gtest_main)
+target_link_libraries(test_queue gtest_main queue)
 add_test(NAME test_queue COMMAND test_queue)

--- a/common/queue/tests/test_queue.cpp
+++ b/common/queue/tests/test_queue.cpp
@@ -109,4 +109,25 @@ TEST(Queue, Empty) {
   EXPECT_FALSE(queue.Empty());
 }
 
+/**
+ * @test Tests that `PopTimed` works.
+ */
+TEST(Queue, PopTimeout) {
+  // Arrange.
+  Queue<int> queue;
+
+  const auto kTimeout = std::chrono::milliseconds(100);
+
+  // Act.
+  int got_element;
+  queue.Push(42);
+  EXPECT_TRUE(queue.PopTimed(kTimeout, &got_element));
+
+  // Next pop should time out.
+  EXPECT_FALSE(queue.PopTimed(kTimeout, &got_element));
+
+  // Assert.
+  EXPECT_EQ(42, got_element);
+}
+
 }  // namespace queue::tests

--- a/common/thread_pool/CMakeLists.txt
+++ b/common/thread_pool/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_subdirectory(tests)
 
 add_library(thread_pool task.cpp thread_pool.cpp)
-target_link_libraries(thread_pool loguru)
+target_link_libraries(thread_pool loguru queue)


### PR DESCRIPTION
This should make it easier to cancel tasks that primarily
wait on a queue for input.